### PR TITLE
Leverage TypeDB Cluster's database management coordination

### DIFF
--- a/cluster/ClusterDatabase.java
+++ b/cluster/ClusterDatabase.java
@@ -41,26 +41,26 @@ class ClusterDatabase implements Database.Cluster {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterDatabase.class);
     private final String name;
     private final Map<String, CoreDatabase> databases;
-    private ClusterClient client;
-    private final ClusterDatabaseManager databaseMgr;
+    private final ClusterClient client;
     private final Set<Replica> replicas;
 
-    private ClusterDatabase(String database, ClusterClient client, ClusterDatabaseManager clusterDatabaseMgr) {
+    private ClusterDatabase(String database, ClusterClient client) {
         this.name = database;
         this.client = client;
-        this.databaseMgr = clusterDatabaseMgr;
         this.databases = new HashMap<>();
         this.replicas = new HashSet<>();
-        for (String address : clusterDatabaseMgr.databaseMgrs().keySet()) {
-            CoreDatabaseManager coreDatabaseMgr = clusterDatabaseMgr.databaseMgrs().get(address);
+
+        ClusterDatabaseManager clusterDbMgr = client.databases();
+        for (String address : clusterDbMgr.databaseMgrs().keySet()) {
+            CoreDatabaseManager coreDatabaseMgr = clusterDbMgr.databaseMgrs().get(address);
             databases.put(address, new CoreDatabase(coreDatabaseMgr, database));
         }
     }
 
-    static ClusterDatabase of(ClusterDatabaseProto.ClusterDatabase protoDB, ClusterClient client, ClusterDatabaseManager clusterDatabaseMgr) {
+    static ClusterDatabase of(ClusterDatabaseProto.ClusterDatabase protoDB, ClusterClient client) {
         assert protoDB.getReplicasCount() > 0;
         String database = protoDB.getName();
-        ClusterDatabase databaseClusterRPC = new ClusterDatabase(database, client, clusterDatabaseMgr);
+        ClusterDatabase databaseClusterRPC = new ClusterDatabase(database, client);
         databaseClusterRPC.replicas().addAll(protoDB.getReplicasList().stream().map(
                 rep -> Replica.of(rep, databaseClusterRPC)
         ).collect(toSet()));

--- a/cluster/ClusterDatabaseManager.java
+++ b/cluster/ClusterDatabaseManager.java
@@ -24,19 +24,21 @@ import grakn.client.api.database.DatabaseManager;
 import grakn.client.common.exception.GraknClientException;
 import grakn.client.core.CoreDatabaseManager;
 import grakn.common.collection.Pair;
-import grakn.protocol.ClusterDatabaseProto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
-import static grakn.client.common.exception.ErrorMessage.Client.CLUSTER_ALL_NODES_FAILED;
-import static grakn.client.common.rpc.RequestBuilder.Cluster.DatabaseManager.allReq;
-import static grakn.client.common.rpc.RequestBuilder.Cluster.DatabaseManager.getReq;
+import static grakn.client.common.exception.ErrorMessage.Client.CLUSTER_REPLICA_NOT_PRIMARY;
+import static grakn.client.common.exception.ErrorMessage.Client.CLUSTER_UNABLE_TO_CONNECT;
 import static grakn.common.collection.Collections.pair;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 public class ClusterDatabaseManager implements DatabaseManager.Cluster {
+    private static final Logger LOG = LoggerFactory.getLogger(FailsafeTask.class);
+
     private final Map<String, CoreDatabaseManager> databaseMgrs;
     private final ClusterClient client;
 
@@ -49,55 +51,51 @@ public class ClusterDatabaseManager implements DatabaseManager.Cluster {
 
     @Override
     public boolean contains(String name) {
-        StringBuilder errors = new StringBuilder();
-        for (String address : databaseMgrs.keySet()) {
-            try {
-                return databaseMgrs.get(address).contains(name);
-            } catch (GraknClientException e) {
-                errors.append("- ").append(address).append(": ").append(e).append("\n");
-            }
-        }
-        throw new GraknClientException(CLUSTER_ALL_NODES_FAILED, errors.toString());
+        return failsafeTask(name, coreDbMgr -> coreDbMgr.contains(name));
     }
 
     @Override
     public void create(String name) {
-        for (CoreDatabaseManager databaseMgr : databaseMgrs.values()) {
-            if (!databaseMgr.contains(name)) {
-                databaseMgr.create(name);
-            }
-        }
+        failsafeTask(name, coreDbMgr -> {
+            coreDbMgr.create(name);
+            return null;
+        });
     }
 
     @Override
     public Database.Cluster get(String name) {
-        StringBuilder errors = new StringBuilder();
-        for (String address : databaseMgrs.keySet()) {
-            try {
-                ClusterDatabaseProto.ClusterDatabaseManager.Get.Res res = client.stub(address).databasesGet(getReq(name));
-                return ClusterDatabase.of(res.getDatabase(), this);
-            } catch (GraknClientException e) {
-                errors.append("- ").append(address).append(": ").append(e).append("\n");
-            }
-        }
-        throw new GraknClientException(CLUSTER_ALL_NODES_FAILED, errors.toString());
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public List<Database.Cluster> all() {
-        StringBuilder errors = new StringBuilder();
-        for (String address : databaseMgrs.keySet()) {
-            try {
-                ClusterDatabaseProto.ClusterDatabaseManager.All.Res res = client.stub(address).databasesAll(allReq());
-                return res.getDatabasesList().stream().map(db -> ClusterDatabase.of(db, this)).collect(toList());
-            } catch (GraknClientException e) {
-                errors.append("- ").append(address).append(": ").append(e).append("\n");
-            }
-        }
-        throw new GraknClientException(CLUSTER_ALL_NODES_FAILED, errors.toString());
+        throw new UnsupportedOperationException();
     }
 
     Map<String, CoreDatabaseManager> databaseMgrs() {
         return databaseMgrs;
+    }
+
+    private <RESULT> RESULT failsafeTask(String name, Function<CoreDatabaseManager, RESULT> task) {
+        FailsafeTask<RESULT> failsafeTask = new FailsafeTask<RESULT>(client, name) {
+
+            @Override
+            RESULT run(ClusterDatabase.Replica replica) {
+                return task.apply(client.coreClient(replica.address()).databases());
+            }
+
+            @Override
+            RESULT rerun(ClusterDatabase.Replica replica) {
+                run(replica);
+                return null;
+            }
+        };
+        try {
+            return failsafeTask.runAnyReplica();
+        } catch (GraknClientException e) {
+            if (CLUSTER_REPLICA_NOT_PRIMARY.equals(e.getErrorMessage())) {
+                return failsafeTask.runPrimaryReplica();
+            } else throw e;
+        }
     }
 }

--- a/cluster/ClusterDatabaseManager.java
+++ b/cluster/ClusterDatabaseManager.java
@@ -74,7 +74,7 @@ public class ClusterDatabaseManager implements DatabaseManager.Cluster {
         return failsafeTask(name, (stub, coreDbMgr) -> {
             if (contains(name)) {
                 ClusterDatabaseProto.ClusterDatabaseManager.Get.Res res = stub.databasesGet(getReq(name));
-                return ClusterDatabase.of(res.getDatabase(), this);
+                return ClusterDatabase.of(res.getDatabase(), client, this);
             }
             else throw new GraknClientException(DB_DOES_NOT_EXIST, name);
         });
@@ -86,7 +86,7 @@ public class ClusterDatabaseManager implements DatabaseManager.Cluster {
         for (String address : databaseMgrs.keySet()) {
             try {
                 ClusterDatabaseProto.ClusterDatabaseManager.All.Res res = client.stub(address).databasesAll(allReq());
-                return res.getDatabasesList().stream().map(db -> ClusterDatabase.of(db, this)).collect(toList());
+                return res.getDatabasesList().stream().map(db -> ClusterDatabase.of(db, client, this)).collect(toList());
             } catch (GraknClientException e) {
                 errors.append("- ").append(address).append(": ").append(e).append("\n");
             }

--- a/cluster/ClusterDatabaseManager.java
+++ b/cluster/ClusterDatabaseManager.java
@@ -74,7 +74,7 @@ public class ClusterDatabaseManager implements DatabaseManager.Cluster {
         return failsafeTask(name, (stub, coreDbMgr) -> {
             if (contains(name)) {
                 ClusterDatabaseProto.ClusterDatabaseManager.Get.Res res = stub.databasesGet(getReq(name));
-                return ClusterDatabase.of(res.getDatabase(), client, this);
+                return ClusterDatabase.of(res.getDatabase(), client);
             }
             else throw new GraknClientException(DB_DOES_NOT_EXIST, name);
         });
@@ -86,7 +86,7 @@ public class ClusterDatabaseManager implements DatabaseManager.Cluster {
         for (String address : databaseMgrs.keySet()) {
             try {
                 ClusterDatabaseProto.ClusterDatabaseManager.All.Res res = client.stub(address).databasesAll(allReq());
-                return res.getDatabasesList().stream().map(db -> ClusterDatabase.of(db, client, this)).collect(toList());
+                return res.getDatabasesList().stream().map(db -> ClusterDatabase.of(db, client)).collect(toList());
             } catch (GraknClientException e) {
                 errors.append("- ").append(address).append(": ").append(e).append("\n");
             }

--- a/cluster/ClusterDatabaseManager.java
+++ b/cluster/ClusterDatabaseManager.java
@@ -108,8 +108,7 @@ public class ClusterDatabaseManager implements DatabaseManager.Cluster {
 
             @Override
             RESULT rerun(ClusterDatabase.Replica replica) {
-                run(replica);
-                return null;
+                return run(replica);
             }
         };
         try {

--- a/cluster/ClusterSession.java
+++ b/cluster/ClusterSession.java
@@ -29,7 +29,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ClusterSession implements GraknSession {
+
     private static final Logger LOG = LoggerFactory.getLogger(GraknSession.class);
+
     private final ClusterClient clusterClient;
     private final GraknOptions.Cluster options;
     private CoreClient coreClient;

--- a/cluster/FailsafeTask.java
+++ b/cluster/FailsafeTask.java
@@ -124,7 +124,7 @@ abstract class FailsafeTask<RESULT> {
             try {
                 LOG.debug("Fetching replica info from {}", serverAddress);
                 ClusterDatabaseProto.ClusterDatabaseManager.Get.Res res = client.stub(serverAddress).databasesGet(getReq(database));
-                ClusterDatabase clusterDatabase = ClusterDatabase.of(res.getDatabase(), client, client.databases());
+                ClusterDatabase clusterDatabase = ClusterDatabase.of(res.getDatabase(), client);
                 client.databaseByName().put(database, clusterDatabase);
                 return clusterDatabase;
             } catch (GraknClientException e) {

--- a/cluster/FailsafeTask.java
+++ b/cluster/FailsafeTask.java
@@ -124,7 +124,7 @@ abstract class FailsafeTask<RESULT> {
             try {
                 LOG.debug("Fetching replica info from {}", serverAddress);
                 ClusterDatabaseProto.ClusterDatabaseManager.Get.Res res = client.stub(serverAddress).databasesGet(getReq(database));
-                ClusterDatabase clusterDatabase = ClusterDatabase.of(res.getDatabase(), client.databases());
+                ClusterDatabase clusterDatabase = ClusterDatabase.of(res.getDatabase(), client, client.databases());
                 client.databaseByName().put(database, clusterDatabase);
                 return clusterDatabase;
             } catch (GraknClientException e) {

--- a/core/CoreDatabaseManager.java
+++ b/core/CoreDatabaseManager.java
@@ -67,6 +67,10 @@ public class CoreDatabaseManager implements DatabaseManager {
         return client.stub();
     }
 
+    public String address() {
+        return client.channel().authority();
+    }
+
     static String nonNull(String name) {
         if (name == null) throw new GraknClientException(MISSING_DB_NAME);
         return name;

--- a/core/CoreDatabaseManager.java
+++ b/core/CoreDatabaseManager.java
@@ -67,10 +67,6 @@ public class CoreDatabaseManager implements DatabaseManager {
         return client.stub();
     }
 
-    public String address() {
-        return client.channel().authority();
-    }
-
     static String nonNull(String name) {
         if (name == null) throw new GraknClientException(MISSING_DB_NAME);
         return name;

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifact():
         artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "ff24c81c3ce821d25df802192db05d6084365161",
+        commit = "e81209e7cd60d516f91ef0797aec9572212b98c2",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -27,10 +27,11 @@ def graknlabs_graql():
     )
 
 def graknlabs_common():
+# TODO: revert to mainline
     git_repository(
         name = "graknlabs_common",
-        remote = "https://github.com/graknlabs/common",
-        tag = "2.0.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        remote = "https://github.com/lolski/common",
+        commit = "c1c94aaaaedaf6c696634eeccf5813d78abf39cc" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_dependencies():


### PR DESCRIPTION
## What is the goal of this PR?

We have removed the workaround for TypeDB Cluster's database management operations. Prior to this PR, the client executes the operation on each server in the cluster.

In this PR, the client only goes to one server and let that server coordinate the operation to the other servers. This is made possible by leveraging the new database management coordination feature that has been implemented in TypeDB Cluster.

## What are the changes implemented in this PR?

- `create`, `get`, and `contains` calls go to any replica, but may optionally go to the primary replica.
- `delete` call must go to the primary replica