### PR TITLE
Allow supplying TypeDBOptions when creating a TypeDB client object

### DIFF
--- a/TypeDB.java
+++ b/TypeDB.java
@@ -22,6 +22,7 @@
 package com.vaticle.typedb.client;
 
 import com.vaticle.typedb.client.api.TypeDBClient;
+import com.vaticle.typedb.client.api.TypeDBOptions;
 import com.vaticle.typedb.client.cluster.ClusterClient;
 import com.vaticle.typedb.client.core.CoreClient;
 
@@ -34,42 +35,26 @@ public class TypeDB {
     public static final String DEFAULT_ADDRESS = "localhost:1729";
 
     public static TypeDBClient coreClient(String address) {
-        return CoreClient.create(address);
+        return CoreClient.create(address, TypeDBOptions.core());
+    }
+
+    public static TypeDBClient coreClient(String address, TypeDBOptions options) {
+        return CoreClient.create(address, options);
     }
 
     public static TypeDBClient coreClient(String address, int parallelisation) {
-        return CoreClient.create(address, parallelisation);
+        return CoreClient.create(address, TypeDBOptions.core(), parallelisation);
     }
 
-    public static TypeDBClient.Cluster clusterClient(String address, boolean tlsEnabled) {
-        return ClusterClient.create(set(address), tlsEnabled, null);
+    public static TypeDBClient coreClient(String address, TypeDBOptions options, int parallelisation) {
+        return CoreClient.create(address, options, parallelisation);
     }
 
-    public static TypeDBClient.Cluster clusterClient(String address, boolean tlsEnabled, String tlsRootCA) {
-        return ClusterClient.create(set(address), tlsEnabled, tlsRootCA);
+    public static TypeDBClient.Cluster clusterClient(String address, TypeDBOptions.Cluster options) {
+        return ClusterClient.create(set(address), options);
     }
 
-    public static TypeDBClient.Cluster clusterClient(String address, boolean tlsEnabled, int parallelisation) {
-        return ClusterClient.create(set(address), tlsEnabled, null, parallelisation);
-    }
-
-    public static TypeDBClient.Cluster clusterClient(String address, boolean tlsEnabled, String tlsRootCA, int parallelisation) {
-        return ClusterClient.create(set(address), tlsEnabled, tlsRootCA, parallelisation);
-    }
-
-    public static TypeDBClient.Cluster clusterClient(Set<String> addresses, boolean tlsEnabled) {
-        return ClusterClient.create(addresses, tlsEnabled, null);
-    }
-
-    public static TypeDBClient.Cluster clusterClient(Set<String> addresses, boolean tlsEnabled, String tlsRootCA) {
-        return ClusterClient.create(addresses, tlsEnabled, tlsRootCA);
-    }
-
-    public static TypeDBClient.Cluster clusterClient(Set<String> addresses, boolean tlsEnabled, int parallelisation) {
-        return ClusterClient.create(addresses, tlsEnabled, null, parallelisation);
-    }
-
-    public static TypeDBClient.Cluster clusterClient(Set<String> addresses, boolean tlsEnabled, String tlsRootCA, int parallelisation) {
-        return ClusterClient.create(addresses, tlsEnabled, tlsRootCA, parallelisation);
+    public static TypeDBClient.Cluster clusterClient(String address, TypeDBOptions.Cluster options, int parallelisation) {
+        return ClusterClient.create(set(address), options, parallelisation);
     }
 }

--- a/api/TypeDBOptions.java
+++ b/api/TypeDBOptions.java
@@ -25,6 +25,8 @@ import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typedb.protocol.OptionsProto;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.NEGATIVE_VALUE_NOT_ALLOWED;
@@ -41,6 +43,8 @@ public class TypeDBOptions {
     private Integer prefetchSize = null;
     private Integer sessionIdleTimeoutMillis = null;
     private Integer schemaLockAcquireTimeoutMillis = null;
+
+    private TypeDBOptions() { }
 
     @CheckReturnValue
     public static TypeDBOptions core() {
@@ -169,7 +173,27 @@ public class TypeDBOptions {
 
     public static class Cluster extends TypeDBOptions {
 
+        private Boolean tlsEnabled = null;
+        private Path tlsRootCA = null;
         private Boolean readAnyReplica = null;
+
+        public Optional<Boolean> tlsEnabled() {
+            return Optional.ofNullable(tlsEnabled);
+        }
+
+        public Cluster tlsEnabled(boolean tlsEnabled) {
+            this.tlsEnabled = tlsEnabled;
+            return this;
+        }
+
+        public Optional<Path> tlsRootCA() {
+            return Optional.ofNullable(tlsRootCA);
+        }
+
+        public Cluster tlsRootCA(Path tlsRootCA) {
+            this.tlsRootCA = tlsRootCA;
+            return this;
+        }
 
         @CheckReturnValue
         public Optional<Boolean> readAnyReplica() {

--- a/cluster/ClusterClient.java
+++ b/cluster/ClusterClient.java
@@ -111,7 +111,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
 
     @Override
     public ClusterSession session(String database, TypeDBSession.Type type) {
-        return session(database, type, options);
+        return session(database, type, TypeDBOptions.cluster());
     }
 
     @Override

--- a/cluster/ClusterNodeClient.java
+++ b/cluster/ClusterNodeClient.java
@@ -21,25 +21,24 @@
 
 package com.vaticle.typedb.client.cluster;
 
+import com.vaticle.typedb.client.api.TypeDBOptions;
 import com.vaticle.typedb.client.common.rpc.ManagedChannelFactory;
 import com.vaticle.typedb.client.core.CoreClient;
 
-import javax.annotation.Nullable;
-import java.nio.file.Path;
-
 class ClusterNodeClient extends CoreClient {
-    public ClusterNodeClient(String address, ManagedChannelFactory managedChannelFactory, int parallelisation) {
-        super(address, managedChannelFactory, parallelisation);
+    public ClusterNodeClient(String address, TypeDBOptions.Cluster options, ManagedChannelFactory managedChannelFactory, int parallelisation) {
+        super(address, options, managedChannelFactory, parallelisation);
     }
 
-    static ClusterNodeClient create(String address, boolean tlsEnabled, @Nullable Path tlsRootCA, int parallelisation) {
+    static ClusterNodeClient create(String address, TypeDBOptions.Cluster options, int parallelisation) {
+        assert options.tlsEnabled().isPresent();
         ManagedChannelFactory channel;
-        if (tlsEnabled) {
-            channel = tlsRootCA != null ? new ManagedChannelFactory.TLS(tlsRootCA) : new ManagedChannelFactory.TLS();
+        if (options.tlsEnabled().get()) {
+            channel = options.tlsRootCA().isPresent() ? new ManagedChannelFactory.TLS(options.tlsRootCA().get()) : new ManagedChannelFactory.TLS();
 
         } else {
             channel = new ManagedChannelFactory.PlainText();
         }
-        return new ClusterNodeClient(address, channel, parallelisation);
+        return new ClusterNodeClient(address, options, channel, parallelisation);
     }
 }

--- a/cluster/ClusterSession.java
+++ b/cluster/ClusterSession.java
@@ -50,7 +50,7 @@ public class ClusterSession implements TypeDBSession {
 
     @Override
     public TypeDBTransaction transaction(TypeDBTransaction.Type type) {
-        return transaction(type, options);
+        return transaction(type, TypeDBOptions.cluster());
     }
 
     @Override

--- a/cluster/ClusterSession.java
+++ b/cluster/ClusterSession.java
@@ -25,9 +25,12 @@ import com.vaticle.typedb.client.api.TypeDBOptions;
 import com.vaticle.typedb.client.api.TypeDBSession;
 import com.vaticle.typedb.client.api.TypeDBTransaction;
 import com.vaticle.typedb.client.api.database.Database;
+import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typedb.client.core.CoreSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
 
 public class ClusterSession implements TypeDBSession {
 
@@ -47,12 +50,16 @@ public class ClusterSession implements TypeDBSession {
 
     @Override
     public TypeDBTransaction transaction(TypeDBTransaction.Type type) {
-        return transaction(type, TypeDBOptions.cluster());
+        return transaction(type, options);
     }
 
     @Override
     public TypeDBTransaction transaction(TypeDBTransaction.Type type, TypeDBOptions options) {
         TypeDBOptions.Cluster clusterOpt = options.asCluster();
+        if (clusterOpt.tlsEnabled().isPresent())
+            throw new TypeDBClientException(ILLEGAL_ARGUMENT, "tlsEnabled");
+        if (clusterOpt.tlsRootCA().isPresent())
+            throw new TypeDBClientException(ILLEGAL_ARGUMENT, "tlsRootCA");
         if (clusterOpt.readAnyReplica().isPresent() && clusterOpt.readAnyReplica().get()) {
             return transactionAnyReplica(type, clusterOpt);
         } else {

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -116,8 +116,10 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Internal(2, "Illegal state has been reached!");
         public static final Internal ILLEGAL_ARGUMENT =
                 new Internal(3, "Illegal argument provided: '%s'");
+        public static final Internal MISSING_ARGUMENT =
+                new Internal(4, "Required argument is not provided: '%s'");
         public static final Internal ILLEGAL_CAST =
-                new Internal(4, "Illegal casting operation to '%s'.");
+                new Internal(5, "Illegal casting operation to '%s'.");
 
         private static final String codePrefix = "INT";
         private static final String messagePrefix = "Internal Error";

--- a/core/CoreClient.java
+++ b/core/CoreClient.java
@@ -86,7 +86,7 @@ public class CoreClient implements TypeDBClient {
 
     @Override
     public CoreSession session(String database, TypeDBSession.Type type) {
-        return session(database, type, options);
+        return session(database, type, TypeDBOptions.core());
     }
 
     @Override

--- a/core/CoreSession.java
+++ b/core/CoreSession.java
@@ -92,7 +92,7 @@ public class CoreSession implements TypeDBSession {
 
     @Override
     public TypeDBTransaction transaction(TypeDBTransaction.Type type) {
-        return transaction(type, options);
+        return transaction(type, TypeDBOptions.core());
     }
 
     @Override

--- a/core/CoreSession.java
+++ b/core/CoreSession.java
@@ -92,7 +92,7 @@ public class CoreSession implements TypeDBSession {
 
     @Override
     public TypeDBTransaction transaction(TypeDBTransaction.Type type) {
-        return transaction(type, TypeDBOptions.core());
+        return transaction(type, options);
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

It is now possible to supply `TypeDBOptions` when constructing a TypeDB or TypeDB Cluster client object. The option will be inherited by sessions and transactions opened from the client object, unless deliberately overridden by the user.

## What are the changes implemented in this PR?

- Make `TypeDB::coreClient` and `TypeDB::clusterClient` accept `TypeDBOptions` and `TypeDBOptions.Cluster`, respectively.
- Make `TypeDBOptions.Cluster` accept TLS parameters: `tlsEnabled` and `tlsRootCA`.