### PR TITLE
Update TypeDB Cluster artifact

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,9 +117,9 @@ load("@vaticle_typeql_lang_java//dependencies/vaticle:repositories.bzl", "vaticl
 vaticle_typeql()
 
 # Load artifacts
-load("//dependencies/vaticle:artifacts.bzl", "vaticle_typedb_artifact", "graknlabs_grakn_cluster_artifact")
+load("//dependencies/vaticle:artifacts.bzl", "vaticle_typedb_artifact", "vaticle_typedb_cluster_artifact")
 vaticle_typedb_artifact()
-graknlabs_grakn_cluster_artifact()
+vaticle_typedb_cluster_artifact()
 
 # Load maven
 load("@vaticle_typeql_lang_java//dependencies/maven:artifacts.bzl", vaticle_typeql_lang_java_artifacts = "artifacts")

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -32,12 +32,12 @@ def vaticle_typedb_artifact():
         commit = "b248793cd5cf97568ae8965ebef14751f4595be9"
     )
 
-def graknlabs_grakn_cluster_artifact():
+def vaticle_typedb_cluster_artifact():
     native_artifact_files(
-        name = "graknlabs_grakn_cluster_artifact",
-        group_name = "graknlabs_grakn_cluster",
-        artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
+        name = "vaticle_typedb_cluster_artifact",
+        group_name = "vaticle_typedb_cluster",
+        artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "e81209e7cd60d516f91ef0797aec9572212b98c2",
+        commit = "3d2d22c53901f5d256f2e6301d96ad3445adc1b9",
     )

--- a/test/BUILD
+++ b/test/BUILD
@@ -34,9 +34,9 @@ native_typedb_artifact(
 
 native_typedb_artifact(
     name = "native-grakn-cluster-artifact",
-    mac_artifact = "@graknlabs_grakn_cluster_artifact_mac//file",
-    linux_artifact = "@graknlabs_grakn_cluster_artifact_linux//file",
-    windows_artifact = "@graknlabs_grakn_cluster_artifact_windows//file",
+    mac_artifact = "@vaticle_typedb_cluster_artifact_mac//file",
+    linux_artifact = "@vaticle_typedb_cluster_artifact_linux//file",
+    windows_artifact = "@vaticle_typedb_cluster_artifact_windows//file",
     output = "grakn-cluster-server-artifact.tar.gz",
     visibility = ["//test:__subpackages__"],
 )

--- a/test/behaviour/concept/thing/attribute/BUILD
+++ b/test/behaviour/concept/thing/attribute/BUILD
@@ -54,9 +54,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/concept/thing/entity/BUILD
+++ b/test/behaviour/concept/thing/entity/BUILD
@@ -56,9 +56,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/concept/thing/relation/BUILD
+++ b/test/behaviour/concept/thing/relation/BUILD
@@ -56,9 +56,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/concept/type/attributetype/BUILD
+++ b/test/behaviour/concept/type/attributetype/BUILD
@@ -54,9 +54,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/concept/type/entitytype/BUILD
+++ b/test/behaviour/concept/type/entitytype/BUILD
@@ -45,9 +45,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/concept/type/relationtype/BUILD
+++ b/test/behaviour/concept/type/relationtype/BUILD
@@ -55,9 +55,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/concept/type/thingtype/BUILD
+++ b/test/behaviour/concept/type/thingtype/BUILD
@@ -56,9 +56,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/connection/database/BUILD
+++ b/test/behaviour/connection/database/BUILD
@@ -85,9 +85,9 @@ typedb_java_test(
     data = [
         "@vaticle_typedb_behaviour//connection:database.feature",
     ],
-    server_mac_artifact = "@graknlabs_grakn_cluster_artifact_mac//file",
-    server_linux_artifact = "@graknlabs_grakn_cluster_artifact_linux//file",
-    server_windows_artifact = "@graknlabs_grakn_cluster_artifact_windows//file",
+    server_mac_artifact = "@vaticle_typedb_cluster_artifact_mac//file",
+    server_linux_artifact = "@vaticle_typedb_cluster_artifact_linux//file",
+    server_windows_artifact = "@vaticle_typedb_cluster_artifact_windows//file",
     runtime_deps = [
         "//test/behaviour/connection:steps-cluster",
 

--- a/test/behaviour/connection/session/BUILD
+++ b/test/behaviour/connection/session/BUILD
@@ -56,9 +56,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/connection/transaction/BUILD
+++ b/test/behaviour/connection/transaction/BUILD
@@ -59,9 +59,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/rules.bzl
+++ b/test/behaviour/rules.bzl
@@ -29,9 +29,9 @@ def typedb_behaviour_java_test(
         typedb_artifact_mac,
         typedb_artifact_linux,
         typedb_artifact_windows,
-        grakn_cluster_artifact_mac,
-        grakn_cluster_artifact_linux,
-        grakn_cluster_artifact_windows,
+        typedb_cluster_artifact_mac,
+        typedb_cluster_artifact_linux,
+        typedb_cluster_artifact_windows,
         runtime_deps = [],
         **kwargs):
 
@@ -46,9 +46,9 @@ def typedb_behaviour_java_test(
 
     typedb_java_test(
         name = name + "-cluster",
-        server_mac_artifact = grakn_cluster_artifact_mac,
-        server_linux_artifact = grakn_cluster_artifact_linux,
-        server_windows_artifact = grakn_cluster_artifact_windows,
+        server_mac_artifact = typedb_cluster_artifact_mac,
+        server_linux_artifact = typedb_cluster_artifact_linux,
+        server_windows_artifact = typedb_cluster_artifact_windows,
         runtime_deps = runtime_deps + [connection_steps_cluster] + steps,
         **kwargs,
     )

--- a/test/behaviour/typeql/language/define/BUILD
+++ b/test/behaviour/typeql/language/define/BUILD
@@ -35,9 +35,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/typeql/language/delete/BUILD
+++ b/test/behaviour/typeql/language/delete/BUILD
@@ -35,9 +35,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/typeql/language/get/BUILD
+++ b/test/behaviour/typeql/language/get/BUILD
@@ -35,9 +35,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/typeql/language/insert/BUILD
+++ b/test/behaviour/typeql/language/insert/BUILD
@@ -35,9 +35,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/typeql/language/match/BUILD
+++ b/test/behaviour/typeql/language/match/BUILD
@@ -35,9 +35,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/typeql/language/undefine/BUILD
+++ b/test/behaviour/typeql/language/undefine/BUILD
@@ -35,9 +35,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [

--- a/test/behaviour/typeql/language/update/BUILD
+++ b/test/behaviour/typeql/language/update/BUILD
@@ -35,9 +35,9 @@ typedb_behaviour_java_test(
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
-    grakn_cluster_artifact_mac = "@graknlabs_grakn_cluster_artifact_mac//file",
-    grakn_cluster_artifact_windows = "@graknlabs_grakn_cluster_artifact_windows//file",
-    grakn_cluster_artifact_linux = "@graknlabs_grakn_cluster_artifact_linux//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
     connection_steps_core = "//test/behaviour/connection:steps-core",
     connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
     steps = [


### PR DESCRIPTION
## What is the goal of this PR?

We've updated TypeDB Cluster artifact. References have been updated, from Grakn Cluster to TypeDB Cluster.

## What are the changes implemented in this PR?

- Updated the artifact definition
- Updated the `typedb_behaviour_java_test`