### PR TITLE
Simplify the "database get" function of the TypeDB Cluster Client

### DIFF
--- a/connection/cluster/ClusterDatabase.java
+++ b/connection/cluster/ClusterDatabase.java
@@ -52,10 +52,10 @@ class ClusterDatabase implements Database.Cluster {
         this.databases = new HashMap<>();
         this.replicas = new HashSet<>();
 
-        ClusterDatabaseManager clusterDbMgr = client.databases();
-        for (String address : clusterDbMgr.databaseMgrs().keySet()) {
-            TypeDBDatabaseManagerImpl coreDatabaseMgr = clusterDbMgr.databaseMgrs().get(address);
-            databases.put(address, new TypeDBDatabaseImpl(coreDatabaseMgr, database));
+        ClusterDatabaseManager clusterDBMgr = client.databases();
+        for (String address : clusterDBMgr.databaseMgrs().keySet()) {
+            TypeDBDatabaseManagerImpl databaseMgr = clusterDBMgr.databaseMgrs().get(address);
+            databases.put(address, new TypeDBDatabaseImpl(databaseMgr, database));
         }
     }
 

--- a/connection/cluster/ClusterDatabaseManager.java
+++ b/connection/cluster/ClusterDatabaseManager.java
@@ -59,21 +59,21 @@ public class ClusterDatabaseManager implements DatabaseManager.Cluster {
 
     @Override
     public boolean contains(String name) {
-        return failsafeTask(name, (stub, coreDbMgr) -> coreDbMgr.contains(name));
+        return failsafeTask(name, (stub, dbMgr) -> dbMgr.contains(name));
     }
 
     @Override
     public void create(String name) {
-        failsafeTask(name, (stub, coreDbMgr) -> {
-            coreDbMgr.create(name);
+        failsafeTask(name, (stub, dbMgr) -> {
+            dbMgr.create(name);
             return null;
         });
     }
 
     @Override
     public Database.Cluster get(String name) {
-        return failsafeTask(name, (stub, coreDbMgr) -> {
-            if (contains(name)) {
+        return failsafeTask(name, (stub, dbMgr) -> {
+            if (dbMgr.contains(name)) {
                 ClusterDatabaseProto.ClusterDatabaseManager.Get.Res res = stub.databasesGet(getReq(name));
                 return ClusterDatabase.of(res.getDatabase(), client);
             } else throw new TypeDBClientException(DB_DOES_NOT_EXIST, name);


### PR DESCRIPTION
## What is the goal of this PR?

We've removed an unnecessary nested failover logic in order to make the logic easier to follow.

## What are the changes implemented in this PR?

- Make `get(...)` call `db.contains` directly rather than the variant that is wrapped in the failover logic.