### PR TITLE
ClusterServerClient owns ClusterServerStub

### DIFF
--- a/connection/cluster/ClusterClient.java
+++ b/connection/cluster/ClusterClient.java
@@ -157,23 +157,23 @@ public class ClusterClient implements TypeDBClient.Cluster {
 
     <RESULT> FailsafeTask<RESULT> createFailsafeTask(
             String database,
-            Function<FailsafeTaskParameter, RESULT> run) {
+            Function<FailsafeTaskParams, RESULT> run) {
         return createFailsafeTask(database, run, run);
     }
 
     <RESULT> FailsafeTask<RESULT> createFailsafeTask(
             String database,
-            Function<FailsafeTaskParameter, RESULT> run,
-            Function<FailsafeTaskParameter, RESULT> rerun
+            Function<FailsafeTaskParams, RESULT> run,
+            Function<FailsafeTaskParams, RESULT> rerun
     ) {
         return new FailsafeTask<RESULT>(database) {
             @Override
-            RESULT run(FailsafeTaskParameter parameter) {
+            RESULT run(FailsafeTaskParams parameter) {
                 return run.apply(parameter);
             }
 
             @Override
-            RESULT rerun(FailsafeTaskParameter parameter) {
+            RESULT rerun(FailsafeTaskParams parameter) {
                 return rerun.apply(parameter);
             }
         };
@@ -208,9 +208,9 @@ public class ClusterClient implements TypeDBClient.Cluster {
             this.database = database;
         }
 
-        abstract RESULT run(FailsafeTaskParameter replica);
+        abstract RESULT run(FailsafeTaskParams replica);
 
-        RESULT rerun(FailsafeTaskParameter replica) {
+        RESULT rerun(FailsafeTaskParams replica) {
             return run(replica);
         }
 
@@ -225,7 +225,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
             int retries = 0;
             while (true) {
                 try {
-                    FailsafeTaskParameter parameter = new FailsafeTaskParameter(
+                    FailsafeTaskParams parameter = new FailsafeTaskParams(
                             clusterServerClient(replica.address()), replica
                     );
                     return retries == 0 ? run(parameter) : rerun(parameter);
@@ -255,7 +255,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
             int retries = 0;
             for (ClusterDatabase.Replica replica : replicas) {
                 try {
-                    FailsafeTaskParameter parameter = new FailsafeTaskParameter(clusterServerClient(replica.address()), replica);
+                    FailsafeTaskParams parameter = new FailsafeTaskParams(clusterServerClient(replica.address()), replica);
                     return retries == 0 ? run(parameter) : rerun(parameter);
                 } catch (TypeDBClientException e) {
                     if (UNABLE_TO_CONNECT.equals(e.getErrorMessage())) {
@@ -318,12 +318,12 @@ public class ClusterClient implements TypeDBClient.Cluster {
         }
     }
 
-    static class FailsafeTaskParameter {
+    static class FailsafeTaskParams {
 
         private final ClusterServerClient client;
         private final ClusterDatabase.Replica replica;
 
-        public FailsafeTaskParameter(ClusterServerClient client, ClusterDatabase.Replica replica) {
+        public FailsafeTaskParams(ClusterServerClient client, ClusterDatabase.Replica replica) {
             this.client = client;
             this.replica = replica;
         }

--- a/connection/cluster/ClusterDatabaseManager.java
+++ b/connection/cluster/ClusterDatabaseManager.java
@@ -85,7 +85,8 @@ public class ClusterDatabaseManager implements DatabaseManager.Cluster {
         StringBuilder errors = new StringBuilder();
         for (String address : databaseMgrs.keySet()) {
             try {
-                ClusterDatabaseProto.ClusterDatabaseManager.All.Res res = client.stub(address).databasesAll(allReq());
+                ClusterDatabaseProto.ClusterDatabaseManager.All.Res res = client.clusterServerClient(address)
+                        .clusterServerStub().databasesAll(allReq());
                 return res.getDatabasesList().stream().map(db -> ClusterDatabase.of(db, client)).collect(toList());
             } catch (TypeDBClientException e) {
                 errors.append("- ").append(address).append(": ").append(e).append("\n");
@@ -102,7 +103,7 @@ public class ClusterDatabaseManager implements DatabaseManager.Cluster {
         ClusterClient.FailsafeTask<RESULT> failsafeTask = client.createFailsafeTask(
                 name,
                 parameter -> task.apply(
-                        parameter.stub(),
+                        parameter.client().clusterServerStub(),
                         parameter.client().databases()
                 )
         );

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -25,13 +25,18 @@ import com.vaticle.typedb.client.api.connection.TypeDBCredential;
 import com.vaticle.typedb.client.connection.TypeDBClientImpl;
 
 class ClusterServerClient extends TypeDBClientImpl {
+    private final ClusterServerStub clusterServerStub;
 
     private ClusterServerClient(String address, TypeDBCredential credential, int parallelisation) {
         super(address, new ClusterServerConnectionFactory(credential), parallelisation);
+        clusterServerStub = ClusterServerStub.create(credential.username(), credential.password(), channel());
     }
 
     static ClusterServerClient create(String address, TypeDBCredential credential, int parallelisation) {
         return new ClusterServerClient(address, credential, parallelisation);
     }
 
+    ClusterServerStub clusterServerStub() {
+        return clusterServerStub;
+    }
 }

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -25,6 +25,7 @@ import com.vaticle.typedb.client.api.connection.TypeDBCredential;
 import com.vaticle.typedb.client.connection.TypeDBClientImpl;
 
 class ClusterServerClient extends TypeDBClientImpl {
+
     private final ClusterServerStub clusterServerStub;
 
     private ClusterServerClient(String address, TypeDBCredential credential, int parallelisation) {

--- a/connection/cluster/ClusterUser.java
+++ b/connection/cluster/ClusterUser.java
@@ -47,7 +47,7 @@ public class ClusterUser implements User {
         ClusterClient.FailsafeTask<Void> failsafeTask = client.createFailsafeTask(
                 SYSTEM_DB,
                 parameter -> {
-                    parameter.stub().userPassword(passwordReq(name, password));
+                    parameter.client().clusterServerStub().userPassword(passwordReq(name, password));
                     return null;
                 }
         );
@@ -59,7 +59,7 @@ public class ClusterUser implements User {
         ClusterClient.FailsafeTask<Void> failsafeTask = client.createFailsafeTask(
                 SYSTEM_DB,
                 parameter -> {
-                    parameter.stub().userDelete(deleteReq(name));
+                    parameter.client().clusterServerStub().userDelete(deleteReq(name));
                     return null;
                 }
         );

--- a/connection/cluster/ClusterUserManager.java
+++ b/connection/cluster/ClusterUserManager.java
@@ -54,7 +54,7 @@ public class ClusterUserManager implements UserManager {
         ClusterClient.FailsafeTask<Boolean> failsafeTask = client.createFailsafeTask(
                 SYSTEM_DB,
                 (parameter) ->
-                        parameter.stub().usersContains(containsReq(name)).getContains()
+                        parameter.client().clusterServerStub().usersContains(containsReq(name)).getContains()
         );
 
         return failsafeTask.runPrimaryReplica();
@@ -65,7 +65,7 @@ public class ClusterUserManager implements UserManager {
         ClusterClient.FailsafeTask<Void> failsafeTask = client.createFailsafeTask(
                 SYSTEM_DB,
                 (parameter) -> {
-                    parameter.stub().usersCreate(createReq(name, password));
+                    parameter.client().clusterServerStub().usersCreate(createReq(name, password));
                     return null;
                 }
         );
@@ -78,7 +78,7 @@ public class ClusterUserManager implements UserManager {
         ClusterClient.FailsafeTask<Set<User>> failsafeTask = client.createFailsafeTask(
                 SYSTEM_DB,
                 (parameter) ->
-                    parameter.stub()
+                    parameter.client().clusterServerStub()
                             .usersAll(allReq()).getNamesList().stream()
                             .map(name -> new ClusterUser(client, name))
                             .collect(Collectors.toSet())


### PR DESCRIPTION
## What is the goal of this PR?

We've made TypeDB Cluster client's `ClusterServerClient` own `ClusterServerStub` instance. This is consistent with TypeDB Client implementation where `TypeDBClientImpl` owns `TypeDBStub`.

## What are the changes implemented in this PR?

Move `ClusterServerStub` instance to be inside `ClusterServerClient`