### PR TITLE
Describe how to disable debug logging in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Further documentation: https://docs.vaticle.com/docs/client-api/java
 
 **Q:** I see a large number of Netty and gRPC log messages. How can I disable them?
 
-**A:** 
+**A:** Create a Logback configuration file and set the minimum log level to ERROR. You can do so with the following steps:
 1. Create a file in your `resources` path (`src/main/resources` by default in a Maven project) named `logback.xml`.
 2. Copy the following document into `logback.xml`:
 ```xml

--- a/README.md
+++ b/README.md
@@ -61,3 +61,25 @@ Further documentation: https://docs.vaticle.com/docs/client-api/java
    bazel-bin/com.vaticle.typedb:api.jar
    bazel-bin/pom.xml
    ```
+
+## FAQs
+
+**Q:** I see a large number of Netty and gRPC log messages. How can I disable them?
+
+**A:** 
+1. Create a file in your `resources` path (`src/main/resources` by default in a Maven project) named `logback.xml`.
+2. Copy the following document into `logback.xml`:
+```xml
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>
+```


### PR DESCRIPTION
## What is the goal of this PR?

A common complaint when using `typedb-client-java` is the large number of Netty and gRPC logs. They are actually easy to disable, but only if you know how. So we added brief instructions to the README.

## What are the changes implemented in this PR?

Describe how to disable debug logging in README
