### PR TITLE
Fix error doing concurrent reads on Java 14-16

### DIFF
--- a/stream/ResponseCollector.java
+++ b/stream/ResponseCollector.java
@@ -31,7 +31,6 @@ import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
 
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.TRANSACTION_CLOSED;
@@ -65,7 +64,7 @@ public class ResponseCollector<R> {
         private final BlockingQueue<Either<Response<R>, Done>> responseQueue;
 
         Queue() {
-            // TODO: We should be using LinkedBlockingQueue here, however there is a bug in Java 14-16: see #351
+            // TODO: switch LinkedTransferQueue to LinkedBlockingQueue once issue #351 is fixed
             responseQueue = new LinkedTransferQueue<>();
         }
 

--- a/stream/ResponseCollector.java
+++ b/stream/ResponseCollector.java
@@ -32,6 +32,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
 
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.TRANSACTION_CLOSED;
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Internal.UNEXPECTED_INTERRUPTION;
@@ -64,7 +65,8 @@ public class ResponseCollector<R> {
         private final BlockingQueue<Either<Response<R>, Done>> responseQueue;
 
         Queue() {
-            responseQueue = new LinkedBlockingQueue<>();
+            // TODO: We should be using LinkedBlockingQueue here, however there is a bug in Java 14-16: see #351
+            responseQueue = new LinkedTransferQueue<>();
         }
 
         public R take() {


### PR DESCRIPTION
## What is the goal of this PR?

Java 14, 15 and 16 all have a bug where `LinkedBlockingQueue.take` can throw an `IllegalMonitorStateException` if you concurrently take from many `LinkedBlockingQueue` (see: #351 )

Although this bug is fixed in Java 18, we need an effective workaround in order to support Java 14-16, so we have changed `ResponseCollector` to be backed by a `LinkedTransferQueue` instead, inflicting a small performance penalty.

## What are the changes implemented in this PR?

Fix error doing concurrent reads on Java 14-16