### PR TITLE
Refactor user token renewal mechanism

### DIFF
--- a/common/rpc/TypeDBStub.java
+++ b/common/rpc/TypeDBStub.java
@@ -89,5 +89,12 @@ public abstract class TypeDBStub {
         }
     }
 
-    protected abstract <RES> RES resilientCall(Supplier<RES> function);
+    protected <RES> RES resilientCall(Supplier<RES> function) {
+        try {
+            ensureConnected();
+            return function.get();
+        } catch (StatusRuntimeException e) {
+            throw TypeDBClientException.of(e);
+        }
+    }
 }

--- a/connection/TypeDBClientImpl.java
+++ b/connection/TypeDBClientImpl.java
@@ -62,6 +62,11 @@ public abstract class TypeDBClientImpl implements TypeDBClient {
     }
 
     @Override
+    public boolean isOpen() {
+        return !channel().isShutdown();
+    }
+
+    @Override
     public TypeDBSessionImpl session(String database, TypeDBSession.Type type) {
         return session(database, type, TypeDBOptions.core());
     }
@@ -77,11 +82,6 @@ public abstract class TypeDBClientImpl implements TypeDBClient {
     @Override
     public TypeDBDatabaseManagerImpl databases() {
         return databaseMgr;
-    }
-
-    @Override
-    public boolean isOpen() {
-        return !channel().isShutdown();
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

We've refactored the user token renewal mechanism so that it no longer awkwardly sits within the `resilientCall` function.

## What are the changes implemented in this PR?

- Move the token renewal mechanism out of `resilientCall`