### PR TITLE
Refactor client creation methods

### DIFF
--- a/TypeDB.java
+++ b/TypeDB.java
@@ -35,27 +35,27 @@ public class TypeDB {
     public static final String DEFAULT_ADDRESS = "localhost:1729";
 
     public static TypeDBClient coreClient(String address) {
-        return CoreClient.create(address);
+        return new CoreClient(address);
     }
 
     public static TypeDBClient coreClient(String address, int parallelisation) {
-        return CoreClient.create(address, parallelisation);
+        return new CoreClient(address, parallelisation);
     }
 
     public static TypeDBClient.Cluster clusterClient(String address, TypeDBCredential credential) {
-        return ClusterClient.create(set(address), credential);
+        return new ClusterClient(set(address), credential);
     }
 
     public static TypeDBClient.Cluster clusterClient(String address, TypeDBCredential credential, int parallelisation) {
-        return ClusterClient.create(set(address), credential, parallelisation);
+        return new ClusterClient(set(address), credential, parallelisation);
     }
 
     public static TypeDBClient.Cluster clusterClient(Set<String> addresses, TypeDBCredential credential) {
-        return ClusterClient.create(addresses, credential);
+        return new ClusterClient(addresses, credential);
     }
 
     public static TypeDBClient.Cluster clusterClient(Set<String> addresses, TypeDBCredential credential, int parallelisation) {
-        return ClusterClient.create(addresses, credential, parallelisation);
+        return new ClusterClient(addresses, credential, parallelisation);
     }
 
 }

--- a/connection/cluster/ClusterClient.java
+++ b/connection/cluster/ClusterClient.java
@@ -67,7 +67,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
         this.credential = credential;
         this.parallelisation = parallelisation;
         clusterServerClients = fetchServerAddresses(addresses).stream()
-                .map(address -> pair(address, ClusterServerClient.create(address, credential, parallelisation)))
+                .map(address -> pair(address, new ClusterServerClient(address, credential, parallelisation)))
                 .collect(toMap(Pair::first, Pair::second));
         userMgr = new ClusterUserManager(this);
         databaseMgr = new ClusterDatabaseManager(this);
@@ -85,7 +85,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
 
     private Set<String> fetchServerAddresses(Set<String> addresses) {
         for (String address : addresses) {
-            try (ClusterServerClient client = ClusterServerClient.create(address, credential, parallelisation)) {
+            try (ClusterServerClient client = new ClusterServerClient(address, credential, parallelisation)) {
                 LOG.debug("Fetching list of cluster servers from {}...", address);
                 ClusterServerStub stub = new ClusterServerStub(client.channel(), credential);
                 ClusterServerProto.ServerManager.All.Res res = stub.serversAll(allReq());

--- a/connection/cluster/ClusterClient.java
+++ b/connection/cluster/ClusterClient.java
@@ -63,7 +63,11 @@ public class ClusterClient implements TypeDBClient.Cluster {
     private final ConcurrentMap<String, ClusterDatabase> clusterDatabases;
     private boolean isOpen;
 
-    private ClusterClient(Set<String> addresses, TypeDBCredential credential, int parallelisation) {
+    public ClusterClient(Set<String> addresses, TypeDBCredential credential) {
+        this(addresses, credential, ClusterServerClient.calculateParallelisation());
+    }
+
+    public ClusterClient(Set<String> addresses, TypeDBCredential credential, int parallelisation) {
         this.credential = credential;
         this.parallelisation = parallelisation;
         clusterServerClients = fetchServerAddresses(addresses).stream()
@@ -73,14 +77,6 @@ public class ClusterClient implements TypeDBClient.Cluster {
         databaseMgr = new ClusterDatabaseManager(this);
         clusterDatabases = new ConcurrentHashMap<>();
         isOpen = true;
-    }
-
-    public static Cluster create(Set<String> addresses, TypeDBCredential credential) {
-        return new ClusterClient(addresses, credential, ClusterServerClient.calculateParallelisation());
-    }
-
-    public static Cluster create(Set<String> addresses, TypeDBCredential credential, int parallelisation) {
-        return new ClusterClient(addresses, credential, parallelisation);
     }
 
     private Set<String> fetchServerAddresses(Set<String> addresses) {

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -36,10 +36,30 @@ class ClusterServerClient extends TypeDBClientImpl {
     private final ManagedChannel channel;
     private final ClusterServerStub stub;
 
-    private ClusterServerClient(String address, TypeDBCredential credential, int parallelisation) {
+    ClusterServerClient(String address, TypeDBCredential credential, int parallelisation) {
         super(parallelisation);
-        channel = newManagedChannel(address, credential);
+        channel = createManagedChannel(address, credential);
         stub = new ClusterServerStub(channel, credential);
+    }
+
+    private ManagedChannel createManagedChannel(String address, TypeDBCredential credential) {
+        if (!credential.tlsEnabled()) {
+            return NettyChannelBuilder.forTarget(address)
+                    .usePlaintext()
+                    .build();
+        } else {
+            try {
+                SslContext sslContext;
+                if (credential.tlsRootCA().isPresent()) {
+                    sslContext = GrpcSslContexts.forClient().trustManager(credential.tlsRootCA().get().toFile()).build();
+                } else {
+                    sslContext = GrpcSslContexts.forClient().build();
+                }
+                return NettyChannelBuilder.forTarget(address).useTransportSecurity().sslContext(sslContext).build();
+            } catch (SSLException e) {
+                throw new TypeDBClientException(e.getMessage(), e);
+            }
+        }
     }
 
     static ClusterServerClient create(String address, TypeDBCredential credential, int parallelisation) {
@@ -54,33 +74,5 @@ class ClusterServerClient extends TypeDBClientImpl {
     @Override
     public ClusterServerStub stub() {
         return stub;
-    }
-
-    private ManagedChannel newManagedChannel(String address, TypeDBCredential credential) {
-        if (!credential.tlsEnabled()) {
-            return plainTextChannel(address);
-        } else {
-            return tlsChannel(address, credential);
-        }
-    }
-
-    private ManagedChannel plainTextChannel(String address) {
-        return NettyChannelBuilder.forTarget(address)
-                .usePlaintext()
-                .build();
-    }
-
-    private ManagedChannel tlsChannel(String address, TypeDBCredential credential) {
-        try {
-            SslContext sslContext;
-            if (credential.tlsRootCA().isPresent()) {
-                sslContext = GrpcSslContexts.forClient().trustManager(credential.tlsRootCA().get().toFile()).build();
-            } else {
-                sslContext = GrpcSslContexts.forClient().build();
-            }
-            return NettyChannelBuilder.forTarget(address).useTransportSecurity().sslContext(sslContext).build();
-        } catch (SSLException e) {
-            throw new TypeDBClientException(e.getMessage(), e);
-        }
     }
 }

--- a/connection/cluster/ClusterServerStub.java
+++ b/connection/cluster/ClusterServerStub.java
@@ -70,8 +70,29 @@ public class ClusterServerStub extends TypeDBStub {
         }
     }
 
-    public static ClusterServerStub create(TypeDBCredential credential, ManagedChannel channel) {
-        return new ClusterServerStub(channel, credential);
+    private CallCredentials createCallCredentials() {
+        return new CallCredentials() {
+            private final Metadata.Key<String> TOKEN_FIELD = Metadata.Key.of("token", ASCII_STRING_MARSHALLER);
+            private final Metadata.Key<String> USERNAME_FIELD = Metadata.Key.of("username", ASCII_STRING_MARSHALLER);
+            private final Metadata.Key<String> PASSWORD_FIELD = Metadata.Key.of("password", ASCII_STRING_MARSHALLER);
+
+            @Override
+            public void applyRequestMetadata(RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {
+                appExecutor.execute(() -> {
+                    Metadata headers = new Metadata();
+                    headers.put(USERNAME_FIELD, credential.username());
+                    if (token != null) {
+                        headers.put(TOKEN_FIELD, token);
+                    } else {
+                        headers.put(PASSWORD_FIELD, credential.password());
+                    }
+                    applier.apply(headers);
+                });
+            }
+
+            @Override
+            public void thisUsesUnstableApi() { }
+        };
     }
 
     public ClusterServerProto.ServerManager.All.Res serversAll(ClusterServerProto.ServerManager.All.Req request) {
@@ -136,30 +157,5 @@ public class ClusterServerStub extends TypeDBStub {
                 }
             } else throw e;
         }
-    }
-
-    private CallCredentials createCallCredentials() {
-        return new CallCredentials() {
-            private final Metadata.Key<String> TOKEN_FIELD = Metadata.Key.of("token", ASCII_STRING_MARSHALLER);
-            private final Metadata.Key<String> USERNAME_FIELD = Metadata.Key.of("username", ASCII_STRING_MARSHALLER);
-            private final Metadata.Key<String> PASSWORD_FIELD = Metadata.Key.of("password", ASCII_STRING_MARSHALLER);
-
-            @Override
-            public void applyRequestMetadata(RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {
-                appExecutor.execute(() -> {
-                    Metadata headers = new Metadata();
-                    headers.put(USERNAME_FIELD, credential.username());
-                    if (token != null) {
-                        headers.put(TOKEN_FIELD, token);
-                    } else {
-                        headers.put(PASSWORD_FIELD, credential.password());
-                    }
-                    applier.apply(headers);
-                });
-            }
-
-            @Override
-            public void thisUsesUnstableApi() { }
-        };
     }
 }

--- a/connection/core/CoreClient.java
+++ b/connection/core/CoreClient.java
@@ -31,18 +31,14 @@ public class CoreClient extends TypeDBClientImpl {
     private final ManagedChannel channel;
     private final TypeDBStub stub;
 
+    public CoreClient(String address) {
+        this(address, calculateParallelisation());
+    }
+
     public CoreClient(String address, int parallelisation) {
         super(parallelisation);
         channel = NettyChannelBuilder.forTarget(address).usePlaintext().build();
         stub = CoreStub.create(channel);
-    }
-
-    public static CoreClient create(String address) {
-        return new CoreClient(address, calculateParallelisation());
-    }
-
-    public static CoreClient create(String address, int parallelisation) {
-        return new CoreClient(address, parallelisation);
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

We've refactored client creation methods, minimising unnecessary boilerplate.

## What are the changes implemented in this PR?

- Remove `create` factory methods of `CoreClient`, `ClusterClient`, and `ClusterServerClient`.
- Reordered methods used only in the constructor to be next to the constructor following our convention.