### PR TITLE
Add and test transaction timeouts

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,6 +126,7 @@ vaticle_typedb_artifact()
 vaticle_typedb_cluster_artifact()
 
 # Load maven
+load("@vaticle_typedb_common//dependencies/maven:artifacts.bzl", vaticle_typedb_common_artifacts = "artifacts")
 load("@vaticle_typeql_lang_java//dependencies/maven:artifacts.bzl", vaticle_typeql_lang_java_artifacts = "artifacts")
 load("@vaticle_factory_tracing//dependencies/maven:artifacts.bzl", vaticle_factory_tracing_artifacts = "artifacts")
 load("//dependencies/maven:artifacts.bzl", vaticle_typedb_client_java_artifacts = "artifacts", vaticle_typedb_client_java_overrides = "overrides")
@@ -137,6 +138,7 @@ load("//dependencies/maven:artifacts.bzl", vaticle_typedb_client_java_artifacts 
 load("@vaticle_dependencies//library/maven:rules.bzl", "maven")
 maven(
     vaticle_factory_tracing_artifacts +
+    vaticle_typedb_common_artifacts +
     vaticle_typeql_lang_java_artifacts +
     vaticle_dependencies_tool_maven_artifacts +
     vaticle_typedb_client_java_artifacts +

--- a/api/TypeDBOptions.java
+++ b/api/TypeDBOptions.java
@@ -40,6 +40,7 @@ public class TypeDBOptions {
     private Boolean prefetch = null;
     private Integer prefetchSize = null;
     private Integer sessionIdleTimeoutMillis = null;
+    private Integer transactionTimeoutMillis = null;
     private Integer schemaLockAcquireTimeoutMillis = null;
 
     private TypeDBOptions() {
@@ -141,6 +142,18 @@ public class TypeDBOptions {
         return Optional.ofNullable(schemaLockAcquireTimeoutMillis);
     }
 
+    public TypeDBOptions transactionTimeoutMillis(int transactionTimeoutMillis) {
+        if (transactionTimeoutMillis < 1) {
+            throw new TypeDBClientException(NEGATIVE_VALUE_NOT_ALLOWED, transactionTimeoutMillis);
+        }
+        this.transactionTimeoutMillis = transactionTimeoutMillis;
+        return this;
+    }
+
+    public Optional<Integer> transactionTimeoutMillis() {
+        return Optional.ofNullable(transactionTimeoutMillis);
+    }
+
     public TypeDBOptions schemaLockAcquireTimeoutMillis(int schemaLockAcquireTimeoutMillis) {
         if (schemaLockAcquireTimeoutMillis < 1) {
             throw new TypeDBClientException(NEGATIVE_VALUE_NOT_ALLOWED, schemaLockAcquireTimeoutMillis);
@@ -164,6 +177,7 @@ public class TypeDBOptions {
         prefetchSize().ifPresent(builder::setPrefetchSize);
         prefetch().ifPresent(builder::setPrefetch);
         sessionIdleTimeoutMillis().ifPresent(builder::setSessionIdleTimeoutMillis);
+        transactionTimeoutMillis().ifPresent(builder::setTransactionTimeoutMillis);
         schemaLockAcquireTimeoutMillis().ifPresent(builder::setSchemaLockAcquireTimeoutMillis);
         if (isCluster()) asCluster().readAnyReplica().ifPresent(builder::setReadAnyReplica);
 

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -34,30 +34,32 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Client(2, "The session has been closed and no further operation is allowed.");
         public static final Client TRANSACTION_CLOSED =
                 new Client(3, "The transaction has been closed and no further operation is allowed.");
+        public static final Client TRANSACTION_CLOSED_WITH_ERRORS =
+                new Client(4, "The transaction has been closed and no further operation is allowed because of error(s): '%s'.");
         public static final Client UNABLE_TO_CONNECT =
-                new Client(4, "Unable to connect to TypeDB server.");
+                new Client(5, "Unable to connect to TypeDB server.");
         public static final Client NEGATIVE_VALUE_NOT_ALLOWED =
-                new Client(5, "Value cannot be less than 1, was: '%d'.");
+                new Client(6, "Value cannot be less than 1, was: '%d'.");
         public static final Client MISSING_DB_NAME =
-                new Client(6, "Database name cannot be null.");
+                new Client(7, "Database name cannot be null.");
         public static final Client DB_DOES_NOT_EXIST =
-                new Client(7, "The database '%s' does not exist.");
+                new Client(8, "The database '%s' does not exist.");
         public static final Client MISSING_RESPONSE =
-                new Client(8, "Unexpected empty response for request ID '%s'.");
+                new Client(9, "Unexpected empty response for request ID '%s'.");
         public static final Client UNKNOWN_REQUEST_ID =
-                new Client(9, "Received a response with unknown request id '%s'.");
+                new Client(10, "Received a response with unknown request id '%s'.");
         public static final Client CLUSTER_NO_PRIMARY_REPLICA_YET =
-                new Client(10, "No replica has been marked as the primary replica for latest known term '%d'.");
+                new Client(11, "No replica has been marked as the primary replica for latest known term '%d'.");
         public static final Client CLUSTER_UNABLE_TO_CONNECT =
-                new Client(11, "Unable to connect to TypeDB Cluster. Attempted connecting to the cluster members, but none are available: '%s'.");
+                new Client(12, "Unable to connect to TypeDB Cluster. Attempted connecting to the cluster members, but none are available: '%s'.");
         public static final Client CLUSTER_REPLICA_NOT_PRIMARY =
-                new Client(12, "The replica is not the primary replica.");
+                new Client(13, "The replica is not the primary replica.");
         public static final Client CLUSTER_ALL_NODES_FAILED =
-                new Client(13, "Attempted connecting to all cluster members, but the following errors occurred: \n%s.");
+                new Client(14, "Attempted connecting to all cluster members, but the following errors occurred: \n%s.");
         public static final Client CLUSTER_USER_DOES_NOT_EXIST =
-                new Client(14, "The user '%s' does not exist.");
+                new Client(15, "The user '%s' does not exist.");
         public static final ErrorMessage CLUSTER_TOKEN_CREDENTIAL_INVALID =
-                new Client(15, "Invalid token credential.");
+                new Client(16, "Invalid token credential.");
 
         private static final String codePrefix = "CLI";
         private static final String messagePrefix = "Client Error";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -35,7 +35,7 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Client TRANSACTION_CLOSED =
                 new Client(3, "The transaction has been closed and no further operation is allowed.");
         public static final Client TRANSACTION_CLOSED_WITH_ERRORS =
-                new Client(4, "The transaction has been closed and no further operation is allowed because of error(s): '%s'.");
+                new Client(4, "The transaction has been closed with error(s): \n%s.");
         public static final Client UNABLE_TO_CONNECT =
                 new Client(5, "Unable to connect to TypeDB server.");
         public static final Client NEGATIVE_VALUE_NOT_ALLOWED =

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -150,5 +150,7 @@
 @maven//:org_slf4j_slf4j_api_1_7_32
 @maven//:org_slf4j_slf4j_simple
 @maven//:org_slf4j_slf4j_simple_1_7_32
+@maven//:org_yaml_snakeyaml
+@maven//:org_yaml_snakeyaml_1_25
 @maven//:org_zeroturnaround_zt_exec
 @maven//:org_zeroturnaround_zt_exec_1_10

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "6ed020e52fe379d1100f64511805ed344c7a68db"
+        commit = "5aa6752e383806199e59f788571f3c324a3e1376"
     )
 
 def vaticle_typedb_cluster_artifact():

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "5aa6752e383806199e59f788571f3c324a3e1376"
+        commit = "af4ddd3d1532399b8fcbff56a239995bf6b2560e"
     )
 
 def vaticle_typedb_cluster_artifact():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -31,8 +31,8 @@ def vaticle_typeql_lang_java():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.5.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/flyingsilverfin/typedb-common",
+        commit = "9b032080ee16a3a5a79688c4fae0f74a35aeb6d0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_dependencies():
@@ -45,15 +45,19 @@ def vaticle_dependencies():
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/vaticle/typedb-protocol",
-        tag = "2.5.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/flyingsilverfin/typedb-protocol",
+        commit = "4a2c87cd9de61c13a155c457b8b4dc817a423ac3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
-    git_repository(
+#    git_repository(
+#        name = "vaticle_typedb_behaviour",
+#        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+#        commit = "3f194fd9f3c282fd8211e6986b8cc4a73831a345", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+#    )
+    native.local_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "042cbf2a6c3b8b9d7a8c3b8d74e796da968523fd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        path = "../typedb-behaviour",
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -53,7 +53,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "036d7f3188c187fee1ce505f282fb43f14b68cd7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "d92d840dd40cc8393936d6f6042820ebcd3a9cef", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -31,8 +31,8 @@ def vaticle_typeql_lang_java():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/flyingsilverfin/typedb-common",
-        commit = "9b032080ee16a3a5a79688c4fae0f74a35aeb6d0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "a436f7c9b64060d7fed718a3be60895c15bd893f" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_dependencies():
@@ -45,19 +45,15 @@ def vaticle_dependencies():
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/flyingsilverfin/typedb-protocol",
-        commit = "4a2c87cd9de61c13a155c457b8b4dc817a423ac3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/vaticle/typedb-protocol",
+        commit = "1399073759831d38b2cdce65f8602234513e1053", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
-#    git_repository(
-#        name = "vaticle_typedb_behaviour",
-#        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-#        commit = "3f194fd9f3c282fd8211e6986b8cc4a73831a345", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
-#    )
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_behaviour",
-        path = "../typedb-behaviour",
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "036d7f3188c187fee1ce505f282fb43f14b68cd7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/stream/BidirectionalStream.java
+++ b/stream/BidirectionalStream.java
@@ -118,10 +118,6 @@ public class BidirectionalStream implements AutoCloseable {
         }
     }
 
-    public boolean hasErrors() {
-        return resCollector.hasErrors() || resPartCollector.hasErrors();
-    }
-
     public List<StatusRuntimeException> drainErrors() {
         List<StatusRuntimeException> errors = new ArrayList<>(resCollector.errors());
         errors.addAll(resPartCollector.errors());

--- a/stream/BidirectionalStream.java
+++ b/stream/BidirectionalStream.java
@@ -32,6 +32,8 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
@@ -114,6 +116,16 @@ public class BidirectionalStream implements AutoCloseable {
                 throw TypeDBClientException.of(e);
             }
         }
+    }
+
+    public boolean hasErrors() {
+        return resCollector.hasErrors() || resPartCollector.hasErrors();
+    }
+
+    public List<StatusRuntimeException> drainErrors() {
+        List<StatusRuntimeException> errors = new ArrayList<>(resCollector.errors());
+        errors.addAll(resPartCollector.errors());
+        return errors;
     }
 
     public static class Single<T> {

--- a/stream/RequestTransmitter.java
+++ b/stream/RequestTransmitter.java
@@ -40,7 +40,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.StampedLock;
 
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLIENT_CLOSED;
-import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.TRANSACTION_CLOSED;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.TRANSACTION_CLOSED_WITH_ERRORS;
 
 public class RequestTransmitter implements AutoCloseable {
 
@@ -164,7 +164,7 @@ public class RequestTransmitter implements AutoCloseable {
         public void dispatch(TransactionProto.Transaction.Req requestProto) {
             try {
                 accessLock.readLock().lock();
-                if (!isOpen.get()) throw new TypeDBClientException(TRANSACTION_CLOSED);
+                if (!isOpen.get()) throw new TypeDBClientException(TRANSACTION_CLOSED_WITH_ERRORS);
                 requestQueue.add(requestProto);
                 executor.mayStartRunning();
             } finally {
@@ -175,7 +175,7 @@ public class RequestTransmitter implements AutoCloseable {
         public void dispatchNow(TransactionProto.Transaction.Req requestProto) {
             try {
                 accessLock.readLock().lock();
-                if (!isOpen.get()) throw new TypeDBClientException(TRANSACTION_CLOSED);
+                if (!isOpen.get()) throw new TypeDBClientException(TRANSACTION_CLOSED_WITH_ERRORS);
                 requestQueue.add(requestProto);
                 sendBatchedRequests();
             } finally {

--- a/stream/RequestTransmitter.java
+++ b/stream/RequestTransmitter.java
@@ -40,7 +40,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.StampedLock;
 
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLIENT_CLOSED;
-import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.TRANSACTION_CLOSED_WITH_ERRORS;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.TRANSACTION_CLOSED;
 
 public class RequestTransmitter implements AutoCloseable {
 
@@ -164,7 +164,7 @@ public class RequestTransmitter implements AutoCloseable {
         public void dispatch(TransactionProto.Transaction.Req requestProto) {
             try {
                 accessLock.readLock().lock();
-                if (!isOpen.get()) throw new TypeDBClientException(TRANSACTION_CLOSED_WITH_ERRORS);
+                if (!isOpen.get()) throw new TypeDBClientException(TRANSACTION_CLOSED);
                 requestQueue.add(requestProto);
                 executor.mayStartRunning();
             } finally {
@@ -175,7 +175,7 @@ public class RequestTransmitter implements AutoCloseable {
         public void dispatchNow(TransactionProto.Transaction.Req requestProto) {
             try {
                 accessLock.readLock().lock();
-                if (!isOpen.get()) throw new TypeDBClientException(TRANSACTION_CLOSED_WITH_ERRORS);
+                if (!isOpen.get()) throw new TypeDBClientException(TRANSACTION_CLOSED);
                 requestQueue.add(requestProto);
                 sendBatchedRequests();
             } finally {

--- a/stream/ResponseCollector.java
+++ b/stream/ResponseCollector.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedTransferQueue;
 
-import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.TRANSACTION_CLOSED_WITH_ERRORS;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.TRANSACTION_CLOSED;
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Internal.UNEXPECTED_INTERRUPTION;
 
 public class ResponseCollector<R> {
@@ -84,7 +84,7 @@ public class ResponseCollector<R> {
             try {
                 Either<Response<R>, Done> response = responseQueue.take();
                 if (response.isFirst()) return response.first().message();
-                else if (!response.second().error().isPresent()) throw new TypeDBClientException(TRANSACTION_CLOSED_WITH_ERRORS);
+                else if (!response.second().error().isPresent()) throw new TypeDBClientException(TRANSACTION_CLOSED);
                 else throw TypeDBClientException.of(response.second().error().get());
             } catch (InterruptedException e) {
                 throw new TypeDBClientException(UNEXPECTED_INTERRUPTION);

--- a/stream/ResponseCollector.java
+++ b/stream/ResponseCollector.java
@@ -60,11 +60,6 @@ public class ResponseCollector<R> {
         collectors.values().forEach(collector -> collector.close(error));
     }
 
-    public boolean hasErrors() {
-        return collectors.values().stream().anyMatch(collector -> collector.responseQueue.stream()
-                .anyMatch(msg -> msg.isSecond() && msg.second().error().isPresent()));
-    }
-
     public List<StatusRuntimeException> errors() {
         List<StatusRuntimeException> errors = new ArrayList<>();
         collectors.values().forEach(collectors -> errors.addAll(collectors.drainErrors()));

--- a/test/behaviour/connection/BUILD
+++ b/test/behaviour/connection/BUILD
@@ -29,6 +29,7 @@ java_library(
         # Package dependencies
         "//api:api",
         "@vaticle_typedb_common//test:typedb-runner",
+        "@vaticle_typedb_common//:common",
 
         # External dependencies from Maven
         "@maven//:junit_junit",

--- a/test/behaviour/connection/ConnectionStepsBase.java
+++ b/test/behaviour/connection/ConnectionStepsBase.java
@@ -28,6 +28,7 @@ import com.vaticle.typedb.client.api.TypeDBTransaction;
 import com.vaticle.typedb.client.api.database.Database;
 import com.vaticle.typedb.common.test.server.TypeDBSingleton;
 import io.cucumber.java.en.Then;
+import io.cucumber.java.sl.In;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -129,5 +130,9 @@ public abstract class ConnectionStepsBase {
     void connection_does_not_have_any_database() {
         assertNotNull(client);
         assertTrue(client.isOpen());
+    }
+
+    void wait_seconds(int seconds) throws InterruptedException {
+        Thread.sleep(seconds * 1000L);
     }
 }

--- a/test/behaviour/connection/ConnectionStepsBase.java
+++ b/test/behaviour/connection/ConnectionStepsBase.java
@@ -132,7 +132,4 @@ public abstract class ConnectionStepsBase {
         assertTrue(client.isOpen());
     }
 
-    void wait_seconds(int seconds) throws InterruptedException {
-        Thread.sleep(seconds * 1000L);
-    }
 }

--- a/test/behaviour/connection/ConnectionStepsBase.java
+++ b/test/behaviour/connection/ConnectionStepsBase.java
@@ -80,7 +80,7 @@ public abstract class ConnectionStepsBase {
             }
         }
         assertNull(client);
-        String address = "localhost:1729" ;//TypeDBSingleton.getTypeDBRunner().address();
+        String address = TypeDBSingleton.getTypeDBRunner().address();
         assertNotNull(address);
         client = createTypeDBClient(address);
         client.databases().all().forEach(Database::delete);

--- a/test/behaviour/connection/ConnectionStepsBase.java
+++ b/test/behaviour/connection/ConnectionStepsBase.java
@@ -27,8 +27,6 @@ import com.vaticle.typedb.client.api.TypeDBSession;
 import com.vaticle.typedb.client.api.TypeDBTransaction;
 import com.vaticle.typedb.client.api.database.Database;
 import com.vaticle.typedb.common.test.server.TypeDBSingleton;
-import io.cucumber.java.en.Then;
-import io.cucumber.java.sl.In;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,9 +59,9 @@ public abstract class ConnectionStepsBase {
     public static TypeDBOptions transactionOptions;
     static boolean isBeforeAllRan = false;
 
-    public static final Map<String, BiConsumer<TypeDBOptions, Integer>> optionSetters = map(
-            pair("session-idle-timeout-millis", TypeDBOptions::sessionIdleTimeoutMillis),
-            pair("transaction-timeout-millis", TypeDBOptions::transactionTimeoutMillis)
+    public static final Map<String, BiConsumer<TypeDBOptions, String>> optionSetters = map(
+            pair("session-idle-timeout-millis", (option, val) -> option.sessionIdleTimeoutMillis(Integer.parseInt(val))),
+            pair("transaction-timeout-millis", (option, val) -> option.transactionTimeoutMillis(Integer.parseInt(val)))
     );
 
     public static TypeDBTransaction tx() {

--- a/test/behaviour/connection/ConnectionStepsCluster.java
+++ b/test/behaviour/connection/ConnectionStepsCluster.java
@@ -30,6 +30,7 @@ import com.vaticle.typedb.common.test.server.TypeDBSingleton;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
@@ -79,4 +80,8 @@ public class ConnectionStepsCluster extends ConnectionStepsBase {
         super.connection_does_not_have_any_database();
     }
 
+    @Then("wait {int} seconds")
+    public void wait_seconds(int seconds) throws InterruptedException {
+        super.wait_seconds(seconds);
+    }
 }

--- a/test/behaviour/connection/ConnectionStepsCluster.java
+++ b/test/behaviour/connection/ConnectionStepsCluster.java
@@ -24,6 +24,7 @@ package com.vaticle.typedb.client.test.behaviour.connection;
 import com.vaticle.typedb.client.TypeDB;
 import com.vaticle.typedb.client.api.TypeDBClient;
 import com.vaticle.typedb.client.api.TypeDBCredential;
+import com.vaticle.typedb.client.api.TypeDBOptions;
 import com.vaticle.typedb.common.test.server.TypeDBClusterRunner;
 import com.vaticle.typedb.common.test.server.TypeDBSingleton;
 import io.cucumber.java.After;
@@ -45,6 +46,7 @@ public class ConnectionStepsCluster extends ConnectionStepsBase {
         }
         server.start();
         TypeDBSingleton.setTypeDBRunner(server);
+        ConnectionStepsBase.isBeforeAllRan = true;
     }
 
     @Before
@@ -60,6 +62,11 @@ public class ConnectionStepsCluster extends ConnectionStepsBase {
     @Override
     TypeDBClient createTypeDBClient(String address) {
         return TypeDB.clusterClient(address, new TypeDBCredential("admin", "password", false));
+    }
+
+    @Override
+    TypeDBOptions createOptions() {
+        return TypeDBOptions.cluster();
     }
 
     @Given("connection has been opened")

--- a/test/behaviour/connection/ConnectionStepsCluster.java
+++ b/test/behaviour/connection/ConnectionStepsCluster.java
@@ -31,6 +31,7 @@ import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
@@ -47,7 +48,6 @@ public class ConnectionStepsCluster extends ConnectionStepsBase {
         }
         server.start();
         TypeDBSingleton.setTypeDBRunner(server);
-        ConnectionStepsBase.isBeforeAllRan = true;
     }
 
     @Before
@@ -80,8 +80,4 @@ public class ConnectionStepsCluster extends ConnectionStepsBase {
         super.connection_does_not_have_any_database();
     }
 
-    @Then("wait {int} seconds")
-    public void wait_seconds(int seconds) throws InterruptedException {
-        super.wait_seconds(seconds);
-    }
 }

--- a/test/behaviour/connection/ConnectionStepsCore.java
+++ b/test/behaviour/connection/ConnectionStepsCore.java
@@ -46,7 +46,6 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
         }
         server.start();
         TypeDBSingleton.setTypeDBRunner(server);
-        ConnectionStepsBase.isBeforeAllRan = true;
     }
 
     @Before
@@ -79,8 +78,4 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
         super.connection_does_not_have_any_database();
     }
 
-    @Then("wait {int} seconds")
-    public void wait_seconds(int seconds) throws InterruptedException {
-        super.wait_seconds(seconds);
-    }
 }

--- a/test/behaviour/connection/ConnectionStepsCore.java
+++ b/test/behaviour/connection/ConnectionStepsCore.java
@@ -23,6 +23,7 @@ package com.vaticle.typedb.client.test.behaviour.connection;
 
 import com.vaticle.typedb.client.TypeDB;
 import com.vaticle.typedb.client.api.TypeDBClient;
+import com.vaticle.typedb.client.api.TypeDBOptions;
 import com.vaticle.typedb.common.test.server.TypeDBCoreRunner;
 import com.vaticle.typedb.common.test.server.TypeDBSingleton;
 import io.cucumber.java.After;
@@ -37,13 +38,14 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
 
     @Override
     void beforeAll() {
-        try {
-            server = new TypeDBCoreRunner();
-        } catch (InterruptedException | TimeoutException | IOException e) {
-            throw new RuntimeException(e);
-        }
-        server.start();
-        TypeDBSingleton.setTypeDBRunner(server);
+//        try {
+//            server = new TypeDBCoreRunner();
+//        } catch (InterruptedException | TimeoutException | IOException e) {
+//            throw new RuntimeException(e);
+//        }
+//        server.start();
+//        TypeDBSingleton.setTypeDBRunner(server);
+        ConnectionStepsBase.isBeforeAllRan = true;
     }
 
     @Before
@@ -59,6 +61,11 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
     @Override
     TypeDBClient createTypeDBClient(String address) {
         return TypeDB.coreClient(address);
+    }
+
+    @Override
+    TypeDBOptions createOptions() {
+        return TypeDBOptions.core();
     }
 
     @Given("connection has been opened")

--- a/test/behaviour/connection/ConnectionStepsCore.java
+++ b/test/behaviour/connection/ConnectionStepsCore.java
@@ -29,6 +29,7 @@ import com.vaticle.typedb.common.test.server.TypeDBSingleton;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
@@ -78,4 +79,8 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
         super.connection_does_not_have_any_database();
     }
 
+    @Then("wait {int} seconds")
+    public void wait_seconds(int seconds) throws InterruptedException {
+        super.wait_seconds(seconds);
+    }
 }

--- a/test/behaviour/connection/ConnectionStepsCore.java
+++ b/test/behaviour/connection/ConnectionStepsCore.java
@@ -38,13 +38,13 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
 
     @Override
     void beforeAll() {
-//        try {
-//            server = new TypeDBCoreRunner();
-//        } catch (InterruptedException | TimeoutException | IOException e) {
-//            throw new RuntimeException(e);
-//        }
-//        server.start();
-//        TypeDBSingleton.setTypeDBRunner(server);
+        try {
+            server = new TypeDBCoreRunner();
+        } catch (InterruptedException | TimeoutException | IOException e) {
+            throw new RuntimeException(e);
+        }
+        server.start();
+        TypeDBSingleton.setTypeDBRunner(server);
         ConnectionStepsBase.isBeforeAllRan = true;
     }
 

--- a/test/behaviour/connection/session/SessionSteps.java
+++ b/test/behaviour/connection/session/SessionSteps.java
@@ -22,6 +22,7 @@
 package com.vaticle.typedb.client.test.behaviour.connection.session;
 
 import com.vaticle.typedb.client.api.TypeDBSession;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
@@ -34,9 +35,12 @@ import static com.vaticle.typedb.client.api.TypeDBSession.Type.DATA;
 import static com.vaticle.typedb.client.api.TypeDBSession.Type.SCHEMA;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.THREAD_POOL_SIZE;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.client;
+import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.optionSetters;
+import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.sessionOptions;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.sessions;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.sessionsParallel;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.threadPool;
+import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.transactionOptions;
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static java.util.Objects.isNull;
 import static org.junit.Assert.assertEquals;
@@ -57,14 +61,14 @@ public class SessionSteps {
     @When("connection open schema session(s) for database(s):")
     public void connection_open_schema_sessions_for_databases(List<String> names) {
         for (String name : names) {
-            sessions.add(client.session(name, SCHEMA));
+            sessions.add(client.session(name, SCHEMA, sessionOptions));
         }
     }
 
     @When("connection open (data )session(s) for database(s):")
     public void connection_open_data_sessions_for_databases(List<String> names) {
         for (String name : names) {
-            sessions.add(client.session(name, DATA));
+            sessions.add(client.session(name, DATA, sessionOptions));
         }
     }
 
@@ -73,7 +77,7 @@ public class SessionSteps {
         assertTrue(THREAD_POOL_SIZE >= names.size());
 
         for (String name : names) {
-            sessionsParallel.add(CompletableFuture.supplyAsync(() -> client.session(name, DATA), threadPool));
+            sessionsParallel.add(CompletableFuture.supplyAsync(() -> client.session(name, DATA, sessionOptions), threadPool));
         }
     }
 
@@ -151,5 +155,18 @@ public class SessionSteps {
         }
 
         CompletableFuture.allOf(assertions).join();
+    }
+
+    @Given("set session option {word} to: {int}")
+    public void set_option_to(String option, int value) {
+        if (!optionSetters.containsKey(option)) {
+            throw new RuntimeException("Unrecognised option: " + option);
+        }
+        optionSetters.get(option).accept(sessionOptions, value);
+    }
+
+    @Then("wait {int} seconds")
+    public void wait_seconds(int seconds) throws InterruptedException {
+        Thread.sleep(seconds * 1000L);
     }
 }

--- a/test/behaviour/connection/session/SessionSteps.java
+++ b/test/behaviour/connection/session/SessionSteps.java
@@ -156,8 +156,8 @@ public class SessionSteps {
         CompletableFuture.allOf(assertions).join();
     }
 
-    @Given("set session option {word} to: {int}")
-    public void set_session_option_to(String option, int value) {
+    @Given("set session option {word} to: {word}")
+    public void set_session_option_to(String option, String value) {
         if (!optionSetters.containsKey(option)) {
             throw new RuntimeException("Unrecognised option: " + option);
         }

--- a/test/behaviour/connection/session/SessionSteps.java
+++ b/test/behaviour/connection/session/SessionSteps.java
@@ -40,7 +40,6 @@ import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStep
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.sessions;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.sessionsParallel;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.threadPool;
-import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.transactionOptions;
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static java.util.Objects.isNull;
 import static org.junit.Assert.assertEquals;
@@ -158,15 +157,10 @@ public class SessionSteps {
     }
 
     @Given("set session option {word} to: {int}")
-    public void set_option_to(String option, int value) {
+    public void set_session_option_to(String option, int value) {
         if (!optionSetters.containsKey(option)) {
             throw new RuntimeException("Unrecognised option: " + option);
         }
         optionSetters.get(option).accept(sessionOptions, value);
-    }
-
-    @Then("wait {int} seconds")
-    public void wait_seconds(int seconds) throws InterruptedException {
-        Thread.sleep(seconds * 1000L);
     }
 }

--- a/test/behaviour/connection/transaction/BUILD
+++ b/test/behaviour/connection/transaction/BUILD
@@ -69,6 +69,7 @@ typedb_behaviour_java_test(
         "//test/behaviour/connection/database:steps",
         "//test/behaviour/connection/session:steps",
         "//test/behaviour/typeql:steps",
+        "//test/behaviour/util:steps",
     ],
     deps = [
         # Internal Package Dependencies

--- a/test/behaviour/connection/transaction/TransactionSteps.java
+++ b/test/behaviour/connection/transaction/TransactionSteps.java
@@ -266,8 +266,8 @@ public class TransactionSteps {
     // transaction configuration          //
     // ===================================//
 
-    @Given("set transaction option {word} to: {int}")
-    public void set_transaction_option_to(String option, int value) {
+    @Given("set transaction option {word} to: {word}")
+    public void set_transaction_option_to(String option, String value) {
         if (!optionSetters.containsKey(option)) {
             throw new RuntimeException("Unrecognised option: " + option);
         }

--- a/test/behaviour/connection/transaction/TransactionSteps.java
+++ b/test/behaviour/connection/transaction/TransactionSteps.java
@@ -267,7 +267,7 @@ public class TransactionSteps {
     // ===================================//
 
     @Given("set transaction option {word} to: {int}")
-    public void set_option_to(String option, int value) {
+    public void set_transaction_option_to(String option, int value) {
         if (!optionSetters.containsKey(option)) {
             throw new RuntimeException("Unrecognised option: " + option);
         }

--- a/test/behaviour/connection/transaction/TransactionSteps.java
+++ b/test/behaviour/connection/transaction/TransactionSteps.java
@@ -21,10 +21,10 @@
 
 package com.vaticle.typedb.client.test.behaviour.connection.transaction;
 
-import com.vaticle.typedb.client.api.TypeDBOptions;
 import com.vaticle.typedb.client.api.TypeDBSession;
 import com.vaticle.typedb.client.api.TypeDBTransaction;
 import com.vaticle.typeql.lang.TypeQL;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.hamcrest.Matchers;
@@ -36,13 +36,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.THREAD_POOL_SIZE;
-import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.client;
+import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.optionSetters;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.sessions;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.sessionsParallel;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.sessionsParallelToTransactionsParallel;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.sessionsToTransactions;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.sessionsToTransactionsParallel;
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.threadPool;
+import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.transactionOptions;
 import static com.vaticle.typedb.client.test.behaviour.util.Util.assertThrows;
 import static com.vaticle.typedb.client.test.behaviour.util.Util.assertThrowsWithMessage;
 import static com.vaticle.typedb.common.collection.Collections.list;
@@ -69,8 +70,7 @@ public class TransactionSteps {
         for (TypeDBSession session : sessions) {
             List<TypeDBTransaction> transactions = new ArrayList<>();
             for (TypeDBTransaction.Type type : types) {
-                TypeDBOptions options = !client.isCluster() ? TypeDBOptions.core() : TypeDBOptions.cluster();
-                TypeDBTransaction transaction = session.transaction(type, options.infer(true));
+                TypeDBTransaction transaction = session.transaction(type, transactionOptions);
                 transactions.add(transaction);
             }
             sessionsToTransactions.put(session, transactions);
@@ -262,6 +262,17 @@ public class TransactionSteps {
         CompletableFuture.allOf(assertions.toArray(new CompletableFuture[0])).join();
     }
 
+    // ===================================//
+    // transaction configuration          //
+    // ===================================//
+
+    @Given("set transaction option {word} to: {int}")
+    public void set_option_to(String option, int value) {
+        if (!optionSetters.containsKey(option)) {
+            throw new RuntimeException("Unrecognised option: " + option);
+        }
+        optionSetters.get(option).accept(transactionOptions, value);
+    }
 
     // ===================================//
     // transaction behaviour with queries //

--- a/test/behaviour/connection/transaction/TransactionTest.java
+++ b/test/behaviour/connection/transaction/TransactionTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.client.test.behaviour",
         features = "external/vaticle_typedb_behaviour/connection/transaction.feature",
-        tags = "not @ignore and not @ignore-typedb-client-java and not @ignore-typedb"
+        tags = "not @ignore and not @ignore-typedb-client-java"
 )
 public class TransactionTest extends BehaviourTest {
     // ATTENTION:

--- a/test/behaviour/util/BUILD
+++ b/test/behaviour/util/BUILD
@@ -25,7 +25,7 @@ load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
 java_library(
     name = "util",
-    srcs = glob(["**/*.java"]),
+    srcs = ["Util.java"],
     visibility = ["//visibility:public"],
     deps = [
 
@@ -34,6 +34,20 @@ java_library(
 
         # External Maven Dependencies
         "@maven//:junit_junit",
+    ],
+)
+
+java_library(
+    name = "steps",
+    srcs = ["UtilSteps.java"],
+    deps = [
+
+        # Internal Repository Dependencies
+        # "@vaticle_typedb_common//:common",
+
+        # External Maven Dependencies
+        "@maven//:junit_junit",
+        "@maven//:io_cucumber_cucumber_java",
     ],
 )
 

--- a/test/behaviour/util/UtilSteps.java
+++ b/test/behaviour/util/UtilSteps.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2021 Vaticle
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.vaticle.typedb.client.test.behaviour.util;
+
+import io.cucumber.java.en.Then;
+
+public class UtilSteps {
+
+    @Then("wait {int} seconds")
+    public void wait_seconds(int seconds) throws InterruptedException {
+        Thread.sleep(seconds * 1000L);
+    }
+}


### PR DESCRIPTION
## What is the goal of this PR?

We implement options for transaction timeout configuration (https://github.com/vaticle/typedb/issues/6487). We also add BDD implementation for new steps required to test transaction timeout and configuring transaction options.

## What are the changes implemented in this PR?

* Add option for transaction timeout (default: 5 mins)
* fix build by adding missing maven dependencies from common
* fix a bug where errors submitted to the response queue were ignored (cleared immediately) - these are now drained from the response queue 
* add missing BDD steps for session and transaction option configuration 

