### PR TITLE
Store error on transaction stream

### DIFF
--- a/connection/TypeDBTransactionImpl.java
+++ b/connection/TypeDBTransactionImpl.java
@@ -39,6 +39,7 @@ import com.vaticle.typedb.protocol.TransactionProto.Transaction.ResPart;
 import io.grpc.StatusRuntimeException;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.TRANSACTION_CLOSED;
@@ -124,9 +125,9 @@ public class TypeDBTransactionImpl implements TypeDBTransaction.Extended {
     }
 
     private void throwTransactionClosed() {
-        List<StatusRuntimeException> errors = bidirectionalStream.getErrors();
-        if (errors.isEmpty()) throw new TypeDBClientException(TRANSACTION_CLOSED);
-        else throw new TypeDBClientException(TRANSACTION_CLOSED_WITH_ERRORS, errors);
+        Optional<StatusRuntimeException> error = bidirectionalStream.getError();
+        if (error.isPresent()) throw new TypeDBClientException(TRANSACTION_CLOSED_WITH_ERRORS, error.get());
+        else throw new TypeDBClientException(TRANSACTION_CLOSED);
     }
 
     @Override

--- a/stream/ResponseCollector.java
+++ b/stream/ResponseCollector.java
@@ -65,12 +65,6 @@ public class ResponseCollector<R> {
         collectors.values().forEach(collector -> collector.close(error));
     }
 
-    List<StatusRuntimeException> getErrors() {
-        List<StatusRuntimeException> errors = new ArrayList<>();
-        collectors.values().forEach(collector -> collector.getError().ifPresent(errors::add));
-        return errors;
-    }
-
     public static class Queue<R> {
 
         private final BlockingQueue<Either<Response<R>, Done>> responseQueue;
@@ -91,10 +85,6 @@ public class ResponseCollector<R> {
             } catch (InterruptedException e) {
                 throw new TypeDBClientException(UNEXPECTED_INTERRUPTION);
             }
-        }
-
-        public Optional<StatusRuntimeException> getError() {
-            return Optional.ofNullable(error);
         }
 
         public void put(R response) {

--- a/stream/ResponsePartIterator.java
+++ b/stream/ResponsePartIterator.java
@@ -92,8 +92,11 @@ public class ResponsePartIterator implements Iterator<TransactionProto.Transacti
 
     @Override
     public TransactionProto.Transaction.ResPart next() {
-        if (!hasNext()) throw new NoSuchElementException();
-        state = State.EMPTY;
-        return next;
+        if (stream.getError().isPresent()) throw TypeDBClientException.of(stream.getError().get());
+        else if (!hasNext()) throw new NoSuchElementException();
+        else {
+            state = State.EMPTY;
+            return next;
+        }
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We store any exceptions received against the transaction stream (as well as query streams) in order to propagate the error to any future transaction operations, not just open query streams.

## What are the changes implemented in this PR?

* store errors against query streams and transaction streams, so we can error on transaction operations against a closed transaction