### PR TITLE
Cluster client throws if the cluster is completely down

### DIFF
--- a/api/TypeDBCredential.java
+++ b/api/TypeDBCredential.java
@@ -21,13 +21,9 @@
 
 package com.vaticle.typedb.client.api;
 
-import com.vaticle.typedb.client.common.exception.TypeDBClientException;
-
 import javax.annotation.Nullable;
 import java.nio.file.Path;
 import java.util.Optional;
-
-import static com.vaticle.typedb.client.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT_COMBINATION;
 
 public class TypeDBCredential {
 

--- a/connection/TypeDBTransactionImpl.java
+++ b/connection/TypeDBTransactionImpl.java
@@ -38,7 +38,6 @@ import com.vaticle.typedb.protocol.TransactionProto.Transaction.Res;
 import com.vaticle.typedb.protocol.TransactionProto.Transaction.ResPart;
 import io.grpc.StatusRuntimeException;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 

--- a/connection/cluster/ClusterClient.java
+++ b/connection/cluster/ClusterClient.java
@@ -45,7 +45,6 @@ import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLU
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.UNABLE_TO_CONNECT;
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Internal.UNEXPECTED_INTERRUPTION;
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.DatabaseManager.getReq;
-import static java.util.stream.Collectors.toMap;
 
 public class ClusterClient implements TypeDBClient.Cluster {
 

--- a/connection/cluster/ClusterClient.java
+++ b/connection/cluster/ClusterClient.java
@@ -64,14 +64,14 @@ public class ClusterClient implements TypeDBClient.Cluster {
     private final ConcurrentMap<String, ClusterDatabase> clusterDatabases;
     private boolean isOpen;
 
-    public ClusterClient(Set<String> initialAddr, TypeDBCredential credential) {
-        this(initialAddr, credential, ClusterServerClient.calculateParallelisation());
+    public ClusterClient(Set<String> initAddresses, TypeDBCredential credential) {
+        this(initAddresses, credential, ClusterServerClient.calculateParallelisation());
     }
 
-    public ClusterClient(Set<String> initialAddr, TypeDBCredential credential, int parallelisation) {
+    public ClusterClient(Set<String> initAddresses, TypeDBCredential credential, int parallelisation) {
         this.credential = credential;
         this.parallelisation = parallelisation;
-        Set<String> addresses = fetchAllAddresses(initialAddr);
+        Set<String> addresses = fetchAllAddresses(initAddresses);
         clusterServerClients = createClients(credential, parallelisation, addresses);
         userMgr = new ClusterUserManager(this);
         databaseMgr = new ClusterDatabaseManager(this);
@@ -79,8 +79,8 @@ public class ClusterClient implements TypeDBClient.Cluster {
         isOpen = true;
     }
 
-    private Set<String> fetchAllAddresses(Set<String> addresses) {
-        for (String address : addresses) {
+    private Set<String> fetchAllAddresses(Set<String> initAddresses) {
+        for (String address : initAddresses) {
             try (ClusterServerClient client = new ClusterServerClient(address, credential, parallelisation)) {
                 return client.addresses();
             } catch (TypeDBClientException e) {
@@ -91,7 +91,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
                 }
             }
         }
-        throw new TypeDBClientException(CLUSTER_UNABLE_TO_CONNECT, String.join(",", addresses));
+        throw new TypeDBClientException(CLUSTER_UNABLE_TO_CONNECT, String.join(",", initAddresses));
     }
 
     private Map<String, ClusterServerClient> createClients(TypeDBCredential credential, int parallelisation, Set<String> addresses) {

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -88,7 +88,7 @@ class ClusterServerClient extends TypeDBClientImpl {
         return stub;
     }
 
-    public Set<String> addresses() {
+    public Set<String> servers() {
         LOG.debug("Fetching list of all servers from server {}...", address);
         ClusterServerProto.ServerManager.All.Res res = stub.serversAll(allReq());
         Set<String> addresses = res.getServersList().stream().map(ClusterServerProto.Server::getAddress).collect(toSet());

--- a/test/behaviour/connection/ConnectionStepsCluster.java
+++ b/test/behaviour/connection/ConnectionStepsCluster.java
@@ -30,8 +30,6 @@ import com.vaticle.typedb.common.test.server.TypeDBSingleton;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
-import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;

--- a/test/behaviour/connection/ConnectionStepsCore.java
+++ b/test/behaviour/connection/ConnectionStepsCore.java
@@ -29,7 +29,6 @@ import com.vaticle.typedb.common.test.server.TypeDBSingleton;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;


### PR DESCRIPTION
## What is the goal of this PR?

Cluster client throws an exception *only* if the cluster is completely down, instead of if any one server is down.

## What are the changes implemented in this PR?

1. Move the connection validation from `ClusterServerClient` to `ClusterClient`, which can make an informed decision whether the connection can be made based on the state of all servers in the cluster.
2. Move the functionality for fetching the list of all addresses from a given server into the `ClusterServerClient` class.
3. Create a function for constructing "cluster server client" instances. The function will throw if none of the servers is available, at the time of invocation.