### PR TITLE
Query iterator only throws exeption once

### DIFF
--- a/connection/TypeDBTransactionImpl.java
+++ b/connection/TypeDBTransactionImpl.java
@@ -56,7 +56,6 @@ public class TypeDBTransactionImpl implements TypeDBTransaction.Extended {
     private final QueryManager queryMgr;
 
     private final BidirectionalStream bidirectionalStream;
-
     TypeDBTransactionImpl(TypeDBSessionImpl session, ByteString sessionId, Type type, TypeDBOptions options) {
         this.type = type;
         this.options = options;

--- a/stream/BidirectionalStream.java
+++ b/stream/BidirectionalStream.java
@@ -76,7 +76,7 @@ public class BidirectionalStream implements AutoCloseable {
         UUID requestID = UUID.randomUUID();
         ResponseCollector.Queue<ResPart> collector = resPartCollector.queue(requestID);
         dispatcher.dispatch(request.setReqId(UUIDAsByteString(requestID)).build());
-        ResponsePartIterator iterator = new ResponsePartIterator(requestID, collector, this);
+        ResponsePartIterator iterator = new ResponsePartIterator(requestID, collector, dispatcher);
         return StreamSupport.stream(spliteratorUnknownSize(iterator, ORDERED | IMMUTABLE), false);
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We revert previous changes from #368 and #364, which made query queues and iterators throw the same error idempotently if there was one. However, this goes counter to standard usages of iterators and queues, which are not meant to behave idempotently (each item is only returned once, and if they have an error they should no longer be used). 

## What are the changes implemented in this PR?

* remove idempotent error state of collectors and queues, which back query iterators