### PR TITLE
Fix memory leak in long-running sessions

### DIFF
--- a/connection/TypeDBSessionImpl.java
+++ b/connection/TypeDBSessionImpl.java
@@ -161,6 +161,10 @@ public class TypeDBSessionImpl implements TypeDBSession {
         }
     }
 
+    public void closed(TypeDBTransaction.Extended typeDBTransaction) {
+        transactions.remove(typeDBTransaction);
+    }
+
     private class PulseTask extends TimerTask {
 
         @Override

--- a/connection/TypeDBSessionImpl.java
+++ b/connection/TypeDBSessionImpl.java
@@ -161,7 +161,7 @@ public class TypeDBSessionImpl implements TypeDBSession {
         }
     }
 
-    public void closed(TypeDBTransaction.Extended typeDBTransaction) {
+    void closed(TypeDBTransaction.Extended typeDBTransaction) {
         transactions.remove(typeDBTransaction);
     }
 

--- a/connection/TypeDBTransactionImpl.java
+++ b/connection/TypeDBTransactionImpl.java
@@ -50,6 +50,7 @@ import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Transaction.ro
 
 public class TypeDBTransactionImpl implements TypeDBTransaction.Extended {
 
+    private final TypeDBSessionImpl session;
     private final TypeDBTransaction.Type type;
     private final TypeDBOptions options;
     private final ConceptManager conceptMgr;
@@ -58,6 +59,7 @@ public class TypeDBTransactionImpl implements TypeDBTransaction.Extended {
 
     private final BidirectionalStream bidirectionalStream;
     TypeDBTransactionImpl(TypeDBSessionImpl session, ByteString sessionId, Type type, TypeDBOptions options) {
+        this.session = session;
         this.type = type;
         this.options = options;
         conceptMgr = new ConceptManagerImpl(this);
@@ -151,5 +153,6 @@ public class TypeDBTransactionImpl implements TypeDBTransaction.Extended {
     @Override
     public void close() {
         bidirectionalStream.close();
+        session.closed(this);
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

A long running session used to keep the reference to each closed transaction, continually growing in size. These references are inaccessible from outside the session object. The problem was compounded in the write transactions, when the caller did not collect the responses received after insert queries, which were held onto by the closed transaction objects.

We now dispose of the closed transaction objects and free their memory.

## What are the changes implemented in this PR?

Transaction now keeps a backreference to the session that spawned it and notifies it when it is closed. The session releases the reference to the transaction and allows the GC to free the memory.