### PR TITLE
Serialise queries without pretty printing

### DIFF
--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "ee90e02d4d74e082912059d31369e836400ff73b",
+        commit = "efeaad5fc9f5dc3a2b217c5ba1abec2d3d7493dd",
     )
 
 def vaticle_typedb_cluster_artifact():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -54,7 +54,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "e2027c081aef20ce249bc8c1d9b5825724892835", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "dbc7464ce314bde11d65243e7653cecfcf7cab08", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,7 +25,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        commit = "6ab52082a5617e897bab9866ff18343648e355eb", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "45a33d90d16923702cea31b5267de693574c9bf7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
@@ -54,7 +54,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "6ff247cf6d90b941da015414cb8f79fc97647a98", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "e2027c081aef20ce249bc8c1d9b5825724892835", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,7 +25,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        commit = "45a33d90d16923702cea31b5267de693574c9bf7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "03a7f5d24e10347142197ef918c438be562ba968", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
@@ -54,7 +54,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "dbc7464ce314bde11d65243e7653cecfcf7cab08", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "69abaf023e1c5837eeeb92d7566e8245dff4bcac", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/query/QueryManagerImpl.java
+++ b/query/QueryManagerImpl.java
@@ -67,12 +67,12 @@ public final class QueryManagerImpl implements QueryManager {
 
     @Override
     public Stream<ConceptMap> match(TypeQLMatch query) {
-        return match(query.toString());
+        return match(query.toString(false));
     }
 
     @Override
     public Stream<ConceptMap> match(TypeQLMatch query, TypeDBOptions options) {
-        return match(query.toString(), options);
+        return match(query.toString(false), options);
     }
 
     @Override
@@ -89,12 +89,12 @@ public final class QueryManagerImpl implements QueryManager {
 
     @Override
     public QueryFuture<Numeric> match(TypeQLMatch.Aggregate query) {
-        return matchAggregate(query.toString());
+        return matchAggregate(query.toString(false));
     }
 
     @Override
     public QueryFuture<Numeric> match(TypeQLMatch.Aggregate query, TypeDBOptions options) {
-        return matchAggregate(query.toString(), options);
+        return matchAggregate(query.toString(false), options);
     }
 
     @Override
@@ -111,12 +111,12 @@ public final class QueryManagerImpl implements QueryManager {
 
     @Override
     public Stream<ConceptMapGroup> match(TypeQLMatch.Group query) {
-        return matchGroup(query.toString());
+        return matchGroup(query.toString(false));
     }
 
     @Override
     public Stream<ConceptMapGroup> match(TypeQLMatch.Group query, TypeDBOptions options) {
-        return matchGroup(query.toString(), options);
+        return matchGroup(query.toString(false), options);
     }
 
     @Override
@@ -133,12 +133,12 @@ public final class QueryManagerImpl implements QueryManager {
 
     @Override
     public Stream<NumericGroup> match(TypeQLMatch.Group.Aggregate query) {
-        return matchGroupAggregate(query.toString());
+        return matchGroupAggregate(query.toString(false));
     }
 
     @Override
     public Stream<NumericGroup> match(TypeQLMatch.Group.Aggregate query, TypeDBOptions options) {
-        return matchGroupAggregate(query.toString(), options);
+        return matchGroupAggregate(query.toString(false), options);
     }
 
     @Override
@@ -155,12 +155,12 @@ public final class QueryManagerImpl implements QueryManager {
 
     @Override
     public Stream<ConceptMap> insert(TypeQLInsert query) {
-        return insert(query.toString());
+        return insert(query.toString(false));
     }
 
     @Override
     public Stream<ConceptMap> insert(TypeQLInsert query, TypeDBOptions options) {
-        return insert(query.toString(), options);
+        return insert(query.toString(false), options);
     }
 
     @Override
@@ -177,12 +177,12 @@ public final class QueryManagerImpl implements QueryManager {
 
     @Override
     public QueryFuture<Void> delete(TypeQLDelete query) {
-        return delete(query.toString());
+        return delete(query.toString(false));
     }
 
     @Override
     public QueryFuture<Void> delete(TypeQLDelete query, TypeDBOptions options) {
-        return delete(query.toString(), options);
+        return delete(query.toString(false), options);
     }
 
     @Override
@@ -197,12 +197,12 @@ public final class QueryManagerImpl implements QueryManager {
 
     @Override
     public Stream<ConceptMap> update(TypeQLUpdate query) {
-        return update(query.toString());
+        return update(query.toString(false));
     }
 
     @Override
     public Stream<ConceptMap> update(TypeQLUpdate query, TypeDBOptions options) {
-        return update(query.toString(), options);
+        return update(query.toString(false), options);
     }
 
     @Override
@@ -219,12 +219,12 @@ public final class QueryManagerImpl implements QueryManager {
 
     @Override
     public QueryFuture<Void> define(TypeQLDefine query) {
-        return define(query.toString());
+        return define(query.toString(false));
     }
 
     @Override
     public QueryFuture<Void> define(TypeQLDefine query, TypeDBOptions options) {
-        return define(query.toString(), options);
+        return define(query.toString(false), options);
     }
 
     @Override
@@ -239,12 +239,12 @@ public final class QueryManagerImpl implements QueryManager {
 
     @Override
     public QueryFuture<Void> undefine(TypeQLUndefine query) {
-        return undefine(query.toString());
+        return undefine(query.toString(false));
     }
 
     @Override
     public QueryFuture<Void> undefine(TypeQLUndefine query, TypeDBOptions options) {
-        return define(query.toString(), options);
+        return define(query.toString(false), options);
     }
 
     @Override

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -69,9 +69,9 @@ public class ClientQueryTest {
 
     @BeforeClass
     public static void setUpClass() throws InterruptedException, IOException, TimeoutException {
-//        typedb = new TypeDBCoreRunner();
-//        typedb.start();
-        typedbClient = TypeDB.coreClient("localhost:1729");
+        typedb = new TypeDBCoreRunner();
+        typedb.start();
+        typedbClient = TypeDB.coreClient(typedb.address());
         if (typedbClient.databases().contains("typedb")) typedbClient.databases().get("typedb").delete();
         typedbClient.databases().create("typedb");
     }
@@ -79,46 +79,7 @@ public class ClientQueryTest {
     @AfterClass
     public static void closeSession() {
         typedbClient.close();
-//        typedb.stop();
-    }
-
-    @Test
-    public void test() {
-        try (TypeDBClient typedbClient = TypeDB.coreClient("localhost:1729")) {
-            java.lang.String valWrite = "a\na";
-            System.out.println("--- to be inserted");
-            System.out.println(valWrite);
-            System.out.println("--- to be inserted");
-            if (typedbClient.databases().contains("typedb")) {
-                typedbClient.databases().get("typedb").delete();
-            }
-            typedbClient.databases().create("typedb");
-            try (TypeDBSession session = typedbClient.session("typedb", TypeDBSession.Type.SCHEMA)) {
-                try (TypeDBTransaction tx = session.transaction(TypeDBTransaction.Type.WRITE)) {
-                    tx.query().define("define person sub entity, owns name, owns user-ssh-private-key; name sub attribute, value string; user-ssh-private-key sub attribute, value string;");
-                    tx.commit();
-                }
-            }
-
-            try (TypeDBSession session = typedbClient.session("typedb", TypeDBSession.Type.DATA)) {
-                try (TypeDBTransaction tx = session.transaction(TypeDBTransaction.Type.WRITE)) {
-                    TypeQLInsert query = TypeQL.insert(var("u").isa("person").has("name", "lolski").has("user-ssh-private-key", valWrite));
-                    System.out.println(query);
-                    tx.query().insert(query);
-                    tx.commit();
-                }
-            }
-
-            try (TypeDBSession session = typedbClient.session("typedb", TypeDBSession.Type.DATA)) {
-                try (TypeDBTransaction tx = session.transaction(TypeDBTransaction.Type.WRITE)) {
-                    List<ConceptMap> answers = tx.query().match(TypeQL.match(var("u").isa("person").has("user-ssh-private-key", var("k")))).collect(Collectors.toList());
-                    String valRead = answers.get(0).get("k").asAttribute().asString().getValue();
-                    System.out.println("--- read");
-                    System.out.println(valRead);
-                    System.out.println("--- read");
-                }
-            }
-        }
+        typedb.stop();
     }
 
     @Test

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -69,9 +69,9 @@ public class ClientQueryTest {
 
     @BeforeClass
     public static void setUpClass() throws InterruptedException, IOException, TimeoutException {
-        typedb = new TypeDBCoreRunner();
-        typedb.start();
-        typedbClient = TypeDB.coreClient(typedb.address());
+//        typedb = new TypeDBCoreRunner();
+//        typedb.start();
+        typedbClient = TypeDB.coreClient("localhost:1729");
         if (typedbClient.databases().contains("typedb")) typedbClient.databases().get("typedb").delete();
         typedbClient.databases().create("typedb");
     }
@@ -79,7 +79,46 @@ public class ClientQueryTest {
     @AfterClass
     public static void closeSession() {
         typedbClient.close();
-        typedb.stop();
+//        typedb.stop();
+    }
+
+    @Test
+    public void test() {
+        try (TypeDBClient typedbClient = TypeDB.coreClient("localhost:1729")) {
+            java.lang.String valWrite = "a\na";
+            System.out.println("--- to be inserted");
+            System.out.println(valWrite);
+            System.out.println("--- to be inserted");
+            if (typedbClient.databases().contains("typedb")) {
+                typedbClient.databases().get("typedb").delete();
+            }
+            typedbClient.databases().create("typedb");
+            try (TypeDBSession session = typedbClient.session("typedb", TypeDBSession.Type.SCHEMA)) {
+                try (TypeDBTransaction tx = session.transaction(TypeDBTransaction.Type.WRITE)) {
+                    tx.query().define("define person sub entity, owns name, owns user-ssh-private-key; name sub attribute, value string; user-ssh-private-key sub attribute, value string;");
+                    tx.commit();
+                }
+            }
+
+            try (TypeDBSession session = typedbClient.session("typedb", TypeDBSession.Type.DATA)) {
+                try (TypeDBTransaction tx = session.transaction(TypeDBTransaction.Type.WRITE)) {
+                    TypeQLInsert query = TypeQL.insert(var("u").isa("person").has("name", "lolski").has("user-ssh-private-key", valWrite));
+                    System.out.println(query);
+                    tx.query().insert(query);
+                    tx.commit();
+                }
+            }
+
+            try (TypeDBSession session = typedbClient.session("typedb", TypeDBSession.Type.DATA)) {
+                try (TypeDBTransaction tx = session.transaction(TypeDBTransaction.Type.WRITE)) {
+                    List<ConceptMap> answers = tx.query().match(TypeQL.match(var("u").isa("person").has("user-ssh-private-key", var("k")))).collect(Collectors.toList());
+                    String valRead = answers.get(0).get("k").asAttribute().asString().getValue();
+                    System.out.println("--- read");
+                    System.out.println(valRead);
+                    System.out.println("--- read");
+                }
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## What is the goal of this PR?

To avoid injecting unintended tab characters into user attributes containing new lines, we utilise TypeQL's new unformatted to string conversion for serialising queries to the server.

## What are the changes implemented in this PR?

Inserting a string with a newline character `insert $x isa blob, has value "Hello \n World"` led to the following formatted TypeQL query:
```
insert
$x isa blob,
  has value "Hello
  World";
```
which on the server side is parsed as: `insert $x isa blobg, has value "Hello \n\t World", which is not the user's actual string! To avoid this, we now serialise using TypeQL's new `toString(pretty = false)` method which does no indentation or newlines, and send this query to the server.

In the new format, the server would receive:
```
insert $x isa blob, has value "Hello 
World";
```

Which does encode exactly what the user intends.
