### PR TITLE
Migrate to Factory

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -39,7 +39,7 @@ build:
         SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
           bazel run @vaticle_dependencies//tool/sonarcloud:code-analysis -- \
           --project-key=vaticle_typedb_client_java \
-          --branch=$GRABL_BRANCH --commit-id=$GRABL_COMMIT
+          --branch=$FACTORY_BRANCH --commit-id=$FACTORY_COMMIT
     dependency-analysis:
       image: vaticle-ubuntu-21.04
       command: |
@@ -73,7 +73,7 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .grabl/test-core.sh //test/behaviour/connection/... --test_output=errors --jobs=1
+        .factory/test-core.sh //test/behaviour/connection/... --test_output=errors --jobs=1
     # TODO: delete --jobs=1 if we fix the issue with excess memory usage
 #    test-behaviour-connection-cluster:
 #      image: vaticle-ubuntu-21.04
@@ -81,7 +81,7 @@ build:
 #        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
 #        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
 #        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .grabl/test-cluster.sh //test/behaviour/connection/... --test_output=errors --jobs=1
+#        .factory/test-cluster.sh //test/behaviour/connection/... --test_output=errors --jobs=1
     # TODO: delete --jobs=1 if we fix the issue with excess memory usage
     test-behaviour-concept-core:
       image: vaticle-ubuntu-21.04
@@ -89,64 +89,64 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .grabl/test-core.sh //test/behaviour/concept/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/concept/... --test_output=errors
 #    test-behaviour-concept-cluster:
 #      image: vaticle-ubuntu-21.04
 #      command: |
 #        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
 #        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
 #        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .grabl/test-cluster.sh //test/behaviour/concept/... --test_output=errors
+#        .factory/test-cluster.sh //test/behaviour/concept/... --test_output=errors
     test-behaviour-match-core:
       image: vaticle-ubuntu-21.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .grabl/test-core.sh //test/behaviour/typeql/language/match/... --test_output=errors
-        .grabl/test-core.sh //test/behaviour/typeql/language/get/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/typeql/language/match/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/typeql/language/get/... --test_output=errors
 #    test-behaviour-match-cluster:
 #      image: vaticle-ubuntu-21.04
 #      command: |
 #        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
 #        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
 #        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .grabl/test-cluster.sh //test/behaviour/typeql/language/match/... --test_output=errors
-#        .grabl/test-cluster.sh //test/behaviour/typeql/language/get/... --test_output=errors
+#        .factory/test-cluster.sh //test/behaviour/typeql/language/match/... --test_output=errors
+#        .factory/test-cluster.sh //test/behaviour/typeql/language/get/... --test_output=errors
     test-behaviour-writable-core:
       image: vaticle-ubuntu-21.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .grabl/test-core.sh //test/behaviour/typeql/language/insert/... --test_output=errors
-        .grabl/test-core.sh //test/behaviour/typeql/language/delete/... --test_output=errors
-        .grabl/test-core.sh //test/behaviour/typeql/language/update/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/typeql/language/insert/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/typeql/language/delete/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/typeql/language/update/... --test_output=errors
     test-behaviour-writable-cluster:
       image: vaticle-ubuntu-21.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .grabl/test-cluster.sh //test/behaviour/typeql/language/insert/... --test_output=errors
-        .grabl/test-cluster.sh //test/behaviour/typeql/language/delete/... --test_output=errors
-        .grabl/test-cluster.sh //test/behaviour/typeql/language/update/... --test_output=errors
+        .factory/test-cluster.sh //test/behaviour/typeql/language/insert/... --test_output=errors
+        .factory/test-cluster.sh //test/behaviour/typeql/language/delete/... --test_output=errors
+        .factory/test-cluster.sh //test/behaviour/typeql/language/update/... --test_output=errors
     test-behaviour-definable-core:
       image: vaticle-ubuntu-21.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .grabl/test-core.sh //test/behaviour/typeql/language/define/... --test_output=errors
-        .grabl/test-core.sh //test/behaviour/typeql/language/undefine/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/typeql/language/define/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/typeql/language/undefine/... --test_output=errors
     test-behaviour-definable-cluster:
       image: vaticle-ubuntu-21.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .grabl/test-cluster.sh //test/behaviour/typeql/language/define/... --test_output=errors
-        .grabl/test-cluster.sh //test/behaviour/typeql/language/undefine/... --test_output=errors
+        .factory/test-cluster.sh //test/behaviour/typeql/language/define/... --test_output=errors
+        .factory/test-cluster.sh //test/behaviour/typeql/language/undefine/... --test_output=errors
     deploy-maven-snapshot:
       image: vaticle-ubuntu-21.04
       dependencies: [
@@ -171,7 +171,7 @@ build:
         owner: vaticle
         branch: master
       command: |
-        export REPO_DIR="/home/grabl/$GRABL_REPO/"
+        export REPO_DIR="/home/factory/$FACTORY_REPO/"
         export TYPEDB_DIST_DIR="dist/typedb-all-linux/"
         bazel run //test:typedb-extractor-linux -- $TYPEDB_DIST_DIR
         export TYPEDB_SVC_PATH="${REPO_DIR//\//\\/}${TYPEDB_DIST_DIR//\//\\/}"
@@ -179,7 +179,7 @@ build:
         sudo systemctl daemon-reload
         sudo systemctl start typedb
 
-        sed -i -e "s/CLIENT_JAVA_VERSION_MARKER/$GRABL_COMMIT/g" test/deployment/pom.xml
+        sed -i -e "s/CLIENT_JAVA_VERSION_MARKER/$FACTORY_COMMIT/g" test/deployment/pom.xml
         cat test/deployment/pom.xml
         cd test/deployment && mvn test
 
@@ -199,9 +199,9 @@ release:
         pyenv global 3.6.10 system
         pip3 install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run @vaticle_dependencies//tool/release/notes:create -- $GRABL_OWNER $GRABL_REPO $GRABL_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
+        bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
+        bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     deploy-maven-release:
       image: vaticle-ubuntu-21.04
       dependencies: [deploy-github]

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -34,19 +34,19 @@ build:
       owner: vaticle
       branch: master
     build-analysis:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
           bazel run @vaticle_dependencies//tool/sonarcloud:code-analysis -- \
           --project-key=vaticle_typedb_client_java \
           --branch=$FACTORY_BRANCH --commit-id=$FACTORY_COMMIT
     dependency-analysis:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -55,20 +55,20 @@ build:
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
     build-dependency:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
     test-integration:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel test //test/integration/... --test_output=errors
     test-behaviour-connection-core:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -76,7 +76,7 @@ build:
         .factory/test-core.sh //test/behaviour/connection/... --test_output=errors --jobs=1
     # TODO: delete --jobs=1 if we fix the issue with excess memory usage
 #    test-behaviour-connection-cluster:
-#      image: vaticle-ubuntu-21.04
+#      image: vaticle-ubuntu-22.04
 #      command: |
 #        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
 #        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -84,21 +84,21 @@ build:
 #        .factory/test-cluster.sh //test/behaviour/connection/... --test_output=errors --jobs=1
     # TODO: delete --jobs=1 if we fix the issue with excess memory usage
     test-behaviour-concept-core:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-core.sh //test/behaviour/concept/... --test_output=errors
 #    test-behaviour-concept-cluster:
-#      image: vaticle-ubuntu-21.04
+#      image: vaticle-ubuntu-22.04
 #      command: |
 #        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
 #        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
 #        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
 #        .factory/test-cluster.sh //test/behaviour/concept/... --test_output=errors
     test-behaviour-match-core:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -106,7 +106,7 @@ build:
         .factory/test-core.sh //test/behaviour/typeql/language/match/... --test_output=errors
         .factory/test-core.sh //test/behaviour/typeql/language/get/... --test_output=errors
 #    test-behaviour-match-cluster:
-#      image: vaticle-ubuntu-21.04
+#      image: vaticle-ubuntu-22.04
 #      command: |
 #        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
 #        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -114,7 +114,7 @@ build:
 #        .factory/test-cluster.sh //test/behaviour/typeql/language/match/... --test_output=errors
 #        .factory/test-cluster.sh //test/behaviour/typeql/language/get/... --test_output=errors
     test-behaviour-writable-core:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -123,7 +123,7 @@ build:
         .factory/test-core.sh //test/behaviour/typeql/language/delete/... --test_output=errors
         .factory/test-core.sh //test/behaviour/typeql/language/update/... --test_output=errors
     test-behaviour-writable-cluster:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -132,7 +132,7 @@ build:
         .factory/test-cluster.sh //test/behaviour/typeql/language/delete/... --test_output=errors
         .factory/test-cluster.sh //test/behaviour/typeql/language/update/... --test_output=errors
     test-behaviour-definable-core:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -140,7 +140,7 @@ build:
         .factory/test-core.sh //test/behaviour/typeql/language/define/... --test_output=errors
         .factory/test-core.sh //test/behaviour/typeql/language/undefine/... --test_output=errors
     test-behaviour-definable-cluster:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -148,7 +148,7 @@ build:
         .factory/test-cluster.sh //test/behaviour/typeql/language/define/... --test_output=errors
         .factory/test-cluster.sh //test/behaviour/typeql/language/undefine/... --test_output=errors
     deploy-maven-snapshot:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [
         build, build-dependency,
         test-behaviour-connection-core, #test-behaviour-connection-cluster,
@@ -165,7 +165,7 @@ build:
         export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //:deploy-maven -- snapshot
     test-deployment-maven:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [deploy-maven-snapshot]
       filter:
         owner: vaticle
@@ -189,21 +189,18 @@ release:
     branch: master
   validation:
     validate-dependencies:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: bazel test //:release-validate-deps --test_output=streamed
   deployment:
     deploy-github:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
-        pyenv install -s 3.6.10
-        pyenv global 3.6.10 system
-        pip3 install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
         bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     deploy-maven-release:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [deploy-github]
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME

--- a/BUILD
+++ b/BUILD
@@ -62,7 +62,7 @@ checkstyle_test(
     size = "small",
     include = glob([
         "*",
-        ".grabl/*",
+        ".factory/*",
     ]),
     exclude = glob([
         "*.md",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TypeDB Client for Java
 
-[![Grabl](https://grabl.io/api/status/vaticle/typedb-client-java/badge.svg)](https://grabl.io/vaticle/typedb-client-java)
+[![Factory](https://factory.vaticle.com/api/status/vaticle/typedb-client-java/badge.svg)](https://factory.vaticle.com/vaticle/typedb-client-java)
 [![Discord](https://img.shields.io/discord/665254494820368395?color=7389D8&label=chat&logo=discord&logoColor=ffffff)](https://vaticle.com/discord)
 [![Discussion Forum](https://img.shields.io/discourse/https/forum.vaticle.com/topics.svg)](https://forum.vaticle.com)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typedb-796de3.svg)](https://stackoverflow.com/questions/tagged/typedb)

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "efeaad5fc9f5dc3a2b217c5ba1abec2d3d7493dd",
+        commit = "b335bfc8a63d0ff8ac57dd0dfa6afa823f7adc1f",
     )
 
 def vaticle_typedb_cluster_artifact():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -24,8 +24,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/jamesreprise/typeql",
-        commit = "9f738b87fdc9443c978e01199dd673df825eb237", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/vaticle/typeql",
+        commit = "20688efec99f40c90c9261c61306e66902135651", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -24,15 +24,15 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/vaticle/typeql",
-        commit = "03a7f5d24e10347142197ef918c438be562ba968", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/jamesreprise/typeql",
+        commit = "9f738b87fdc9443c978e01199dd673df825eb237", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "3ac0c1069986f8f5dc90aebf06facfb2cb2016f1" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "17c162fe7135db6988d7ac1ae5416568231c8789" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
 
     )
 
@@ -40,26 +40,26 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "a8b3b714a5e0562d41f4c05ca8f266d48b7d0fd3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "4464b506ca469f37d3b696fb2f1eda34061cdaa1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
-        commit = "6d47f21951abf2752ed65525cf17e9ecaef131e1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "192ee408a841130d75da9ca67630263126da3bd4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "69abaf023e1c5837eeeb92d7566e8245dff4bcac", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "a503356d9d22e794393ced5b3d3f014db4189b60", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():
     git_repository(
         name = "vaticle_factory_tracing",
         remote = "https://github.com/vaticle/factory-tracing",
-        commit = "a4d5e36b1b0c56bd370e5a7583d628de9272f086"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
+        commit = "e61d2d00e0c0321406da5fed14bd32ccb41cf03c"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
     )


### PR DESCRIPTION
## What is the goal of this PR?

We've migrated our continuous integration for this repo to Vaticle Factory from Grabl.

## What are the changes implemented in this PR?

We've updated:
- dependencies.
- uses of pyenv that are no longer in line with our approach.
- machine definitions from ubuntu 21.04 to 22.04.

## Additional info

We don't intend to merge this change while we are still depending upon my fork of TypeQL. This will be changed once the relevant PR for TypeQL has been merged:
- https://github.com/vaticle/typeql/pull/244
