### PR TITLE
Fix for deploying to GitHub, bump dependencies

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -195,6 +195,13 @@ release:
     deploy-github:
       image: vaticle-ubuntu-22.04
       command: |
+        export PYENV_ROOT="/opt/pyenv"
+        pyenv install 3.7.9
+        pyenv global 3.7.9
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
+        python3 -m pip install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "b335bfc8a63d0ff8ac57dd0dfa6afa823f7adc1f",
+        commit = "9987d2c82b86a068ea40550d473dc5d75ed288aa",
     )
 
 def vaticle_typedb_cluster_artifact():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,15 +25,14 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        commit = "20688efec99f40c90c9261c61306e66902135651", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        tag = "2.12.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "17c162fe7135db6988d7ac1ae5416568231c8789" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
-
+        tag = "2.12.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_dependencies():
@@ -47,19 +46,19 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
-        commit = "192ee408a841130d75da9ca67630263126da3bd4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        tag = "2.12.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "a503356d9d22e794393ced5b3d3f014db4189b60", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "17c3764aa3cce285523a566910fe716895f77c35", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():
     git_repository(
         name = "vaticle_factory_tracing",
         remote = "https://github.com/vaticle/factory-tracing",
-        commit = "e61d2d00e0c0321406da5fed14bd32ccb41cf03c"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
+        tag = "2.9.0"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -60,5 +60,5 @@ def vaticle_factory_tracing():
     git_repository(
         name = "vaticle_factory_tracing",
         remote = "https://github.com/vaticle/factory-tracing",
-        tag = "2.9.0"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
+        commit = "ec2ca026d81213e9f2a56c9b336defd99fda6931"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
     )


### PR DESCRIPTION
## What is the goal of this PR?

We've fixed the job involving deploying to GitHub and bumped dependencies in preparation for a release.

## What are the changes implemented in this PR?

We've fixed various released dependencies of client-java to their tagged release versions. We've also added instructions to our CI fixing deploying releases to GitHub.