### PR TITLE
Use latest typedb artifact

### DIFF
--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "1248eb43c7f0c3577e7da2b10254305ce2def0a9",
+        tag = "2.14.3",
     )
 
 def vaticle_typedb_cluster_artifact():


### PR DESCRIPTION
## What is the goal of this PR?

We updated the `typedb` artifact to the latest released version `2.14.3`.