### PR TITLE
Cluster password policy and user management support

### DIFF
--- a/api/user/User.java
+++ b/api/user/User.java
@@ -28,11 +28,7 @@ public interface User {
     @CheckReturnValue
     String username();
 
-    void password(String oldPassword, String newPassword);
+    long passwordExpiryDays();
 
-    void passwordAdmin(String password);
-
-    long expiryDays();
-
-    void delete();
+    void passwordUpdate(String oldPassword, String newPassword);
 }

--- a/api/user/User.java
+++ b/api/user/User.java
@@ -28,7 +28,11 @@ public interface User {
     @CheckReturnValue
     String username();
 
-    void password(String password);
+    void password(String oldPassword, String newPassword);
+
+    void passwordAdmin(String password);
+
+    long expiryDays(String username);
 
     void delete();
 }

--- a/api/user/User.java
+++ b/api/user/User.java
@@ -32,7 +32,7 @@ public interface User {
 
     void passwordAdmin(String password);
 
-    long expiryDays(String username);
+    long expiryDays();
 
     void delete();
 }

--- a/api/user/User.java
+++ b/api/user/User.java
@@ -31,5 +31,5 @@ public interface User {
 
     Optional<Long> passwordExpiryDays();
 
-    void passwordUpdate(String oldPassword, String newPassword);
+    void passwordUpdate(String passwordOld, String passwordNew);
 }

--- a/api/user/User.java
+++ b/api/user/User.java
@@ -22,13 +22,14 @@
 package com.vaticle.typedb.client.api.user;
 
 import javax.annotation.CheckReturnValue;
+import java.util.Optional;
 
 public interface User {
 
     @CheckReturnValue
     String username();
 
-    long passwordExpiryDays();
+    Optional<Long> passwordExpiryDays();
 
     void passwordUpdate(String oldPassword, String newPassword);
 }

--- a/api/user/UserManager.java
+++ b/api/user/UserManager.java
@@ -34,5 +34,9 @@ public interface UserManager {
 
     void create(String username, String password);
 
+    void delete(String username);
+
     Set<User> all();
+
+    void passwordSet(String username, String password);
 }

--- a/api/user/UserManager.java
+++ b/api/user/UserManager.java
@@ -27,9 +27,6 @@ import java.util.Set;
 public interface UserManager {
 
     @CheckReturnValue
-    User get(String username);
-
-    @CheckReturnValue
     boolean contains(String username);
 
     void create(String username, String password);
@@ -39,4 +36,7 @@ public interface UserManager {
     Set<User> all();
 
     void passwordSet(String username, String password);
+
+    @CheckReturnValue
+    User get(String username);
 }

--- a/api/user/UserManager.java
+++ b/api/user/UserManager.java
@@ -33,10 +33,10 @@ public interface UserManager {
 
     void delete(String username);
 
+    @CheckReturnValue
+    User get(String username);
+
     Set<User> all();
 
     void passwordSet(String username, String password);
-
-    @CheckReturnValue
-    User get(String username);
 }

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -137,9 +137,7 @@ public class RequestBuilder {
 
             public static ClusterUserProto.ClusterUserManager.PasswordSet.Req passwordSetReq(String username, String password) {
                 return ClusterUserProto.ClusterUserManager.PasswordSet.Req.newBuilder()
-                        .setUsername(username)
-                        .setPassword(password)
-                        .build();
+                        .setUsername(username).setPassword(password).build();
             }
 
             public static ClusterUserProto.ClusterUserManager.Get.Req getReq(String username) {
@@ -151,10 +149,7 @@ public class RequestBuilder {
 
             public static ClusterUserProto.ClusterUser.PasswordUpdate.Req passwordUpdateReq(String username, String oldPassword, String newPassword) {
                 return ClusterUserProto.ClusterUser.PasswordUpdate.Req.newBuilder()
-                        .setUsername(username)
-                        .setOldPassword(oldPassword)
-                        .setNewPassword(newPassword)
-                        .build();
+                        .setUsername(username).setOldPassword(oldPassword).setNewPassword(newPassword).build();
             }
 
             public static ClusterUserProto.ClusterUser.Token.Req tokenReq(String username) {

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -147,9 +147,9 @@ public class RequestBuilder {
 
         public static class User {
 
-            public static ClusterUserProto.ClusterUser.PasswordUpdate.Req passwordUpdateReq(String username, String oldPassword, String newPassword) {
+            public static ClusterUserProto.ClusterUser.PasswordUpdate.Req passwordUpdateReq(String username, String passwordOld, String passwordNew) {
                 return ClusterUserProto.ClusterUser.PasswordUpdate.Req.newBuilder()
-                        .setUsername(username).setOldPassword(oldPassword).setNewPassword(newPassword).build();
+                        .setUsername(username).setPasswordOld(passwordOld).setPasswordNew(passwordNew).build();
             }
 
             public static ClusterUserProto.ClusterUser.Token.Req tokenReq(String username) {

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -127,38 +127,38 @@ public class RequestBuilder {
                 return ClusterUserProto.ClusterUserManager.Create.Req.newBuilder().setUsername(username).setPassword(password).build();
             }
 
+            public static ClusterUserProto.ClusterUserManager.Delete.Req deleteReq(String username) {
+                return ClusterUserProto.ClusterUserManager.Delete.Req.newBuilder().setUsername(username).build();
+            }
+
             public static ClusterUserProto.ClusterUserManager.All.Req allReq() {
                 return ClusterUserProto.ClusterUserManager.All.Req.newBuilder().build();
+            }
+
+            public static ClusterUserProto.ClusterUserManager.PasswordSet.Req passwordSetReq(String username, String password) {
+                return ClusterUserProto.ClusterUserManager.PasswordSet.Req.newBuilder()
+                        .setUsername(username)
+                        .setPassword(password)
+                        .build();
+            }
+
+            public static ClusterUserProto.ClusterUserManager.Get.Req getReq(String username) {
+                return ClusterUserProto.ClusterUserManager.Get.Req.newBuilder().setUsername(username).build();
             }
         }
 
         public static class User {
 
-            public static ClusterUserProto.ClusterUser.Password.Req passwordReq(String username, String oldPassword, String newPassword) {
-                return ClusterUserProto.ClusterUser.Password.Req.newBuilder()
+            public static ClusterUserProto.ClusterUser.PasswordUpdate.Req passwordUpdateReq(String username, String oldPassword, String newPassword) {
+                return ClusterUserProto.ClusterUser.PasswordUpdate.Req.newBuilder()
                         .setUsername(username)
                         .setOldPassword(oldPassword)
                         .setNewPassword(newPassword)
                         .build();
             }
 
-            public static ClusterUserProto.ClusterUser.PasswordAdmin.Req passwordAdminReq(String username, String password) {
-                return ClusterUserProto.ClusterUser.PasswordAdmin.Req.newBuilder()
-                        .setUsername(username)
-                        .setPassword(password)
-                        .build();
-            }
-
-            public static ClusterUserProto.ClusterUser.ExpiryDays.Req expiryDaysReq(String username) {
-                return ClusterUserProto.ClusterUser.ExpiryDays.Req.newBuilder().setUsername(username).build();
-            }
-
             public static ClusterUserProto.ClusterUser.Token.Req tokenReq(String username) {
                 return ClusterUserProto.ClusterUser.Token.Req.newBuilder().setUsername(username).build();
-            }
-
-            public static ClusterUserProto.ClusterUser.Delete.Req deleteReq(String username) {
-                return ClusterUserProto.ClusterUser.Delete.Req.newBuilder().setUsername(username).build();
             }
         }
 

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -134,8 +134,23 @@ public class RequestBuilder {
 
         public static class User {
 
-            public static ClusterUserProto.ClusterUser.Password.Req passwordReq(String username, String password) {
-                return ClusterUserProto.ClusterUser.Password.Req.newBuilder().setUsername(username).setPassword(password).build();
+            public static ClusterUserProto.ClusterUser.Password.Req passwordReq(String username, String oldPassword, String newPassword) {
+                return ClusterUserProto.ClusterUser.Password.Req.newBuilder()
+                        .setUsername(username)
+                        .setOldPassword(oldPassword)
+                        .setNewPassword(newPassword)
+                        .build();
+            }
+
+            public static ClusterUserProto.ClusterUser.PasswordAdmin.Req passwordAdminReq(String username, String password) {
+                return ClusterUserProto.ClusterUser.PasswordAdmin.Req.newBuilder()
+                        .setUsername(username)
+                        .setPassword(password)
+                        .build();
+            }
+
+            public static ClusterUserProto.ClusterUser.ExpiryDays.Req expiryDaysReq(String username) {
+                return ClusterUserProto.ClusterUser.ExpiryDays.Req.newBuilder().setUsername(username).build();
             }
 
             public static ClusterUserProto.ClusterUser.Token.Req tokenReq(String username) {

--- a/connection/cluster/ClusterServerStub.java
+++ b/connection/cluster/ClusterServerStub.java
@@ -119,6 +119,15 @@ public class ClusterServerStub extends TypeDBStub {
         return mayRenewToken(() -> clusterBlockingStub.userPassword(request));
     }
 
+    public ClusterUserProto.ClusterUser.PasswordAdmin.Res userPasswordAdmin(ClusterUserProto.ClusterUser.PasswordAdmin.Req request) {
+        return mayRenewToken(() -> clusterBlockingStub.userPasswordAdmin(request));
+    }
+
+    public ClusterUserProto.ClusterUser.ExpiryDays.Res userExpiryDays(ClusterUserProto.ClusterUser.ExpiryDays.Req request) {
+        return mayRenewToken(() -> clusterBlockingStub.userExpiryDays(request));
+    }
+
+
     public ClusterUserProto.ClusterUser.Delete.Res userDelete(ClusterUserProto.ClusterUser.Delete.Req request) {
         return mayRenewToken(() -> clusterBlockingStub.userDelete(request));
     }

--- a/connection/cluster/ClusterServerStub.java
+++ b/connection/cluster/ClusterServerStub.java
@@ -119,12 +119,12 @@ public class ClusterServerStub extends TypeDBStub {
         return mayRenewToken(() -> clusterBlockingStub.usersAll(request));
     }
 
-    public ClusterUserProto.ClusterUserManager.PasswordSet.Res userPasswordSet(ClusterUserProto.ClusterUserManager.PasswordSet.Req request) {
-        return mayRenewToken(() -> clusterBlockingStub.userPasswordSet(request));
+    public ClusterUserProto.ClusterUserManager.PasswordSet.Res usersPasswordSet(ClusterUserProto.ClusterUserManager.PasswordSet.Req request) {
+        return mayRenewToken(() -> clusterBlockingStub.usersPasswordSet(request));
     }
 
-    public ClusterUserProto.ClusterUserManager.Get.Res userGet(ClusterUserProto.ClusterUserManager.Get.Req request) {
-        return mayRenewToken(() -> clusterBlockingStub.userGet(request));
+    public ClusterUserProto.ClusterUserManager.Get.Res usersGet(ClusterUserProto.ClusterUserManager.Get.Req request) {
+        return mayRenewToken(() -> clusterBlockingStub.usersGet(request));
     }
 
     public ClusterUserProto.ClusterUser.PasswordUpdate.Res userPasswordUpdate(ClusterUserProto.ClusterUser.PasswordUpdate.Req request) {

--- a/connection/cluster/ClusterServerStub.java
+++ b/connection/cluster/ClusterServerStub.java
@@ -111,25 +111,24 @@ public class ClusterServerStub extends TypeDBStub {
         return mayRenewToken(() -> clusterBlockingStub.usersCreate(request));
     }
 
+    public ClusterUserProto.ClusterUserManager.Delete.Res usersDelete(ClusterUserProto.ClusterUserManager.Delete.Req request) {
+        return mayRenewToken(() -> clusterBlockingStub.usersDelete(request));
+    }
+
     public ClusterUserProto.ClusterUserManager.All.Res usersAll(ClusterUserProto.ClusterUserManager.All.Req request) {
         return mayRenewToken(() -> clusterBlockingStub.usersAll(request));
     }
 
-    public ClusterUserProto.ClusterUser.Password.Res userPassword(ClusterUserProto.ClusterUser.Password.Req request) {
-        return mayRenewToken(() -> clusterBlockingStub.userPassword(request));
+    public ClusterUserProto.ClusterUserManager.PasswordSet.Res userPasswordSet(ClusterUserProto.ClusterUserManager.PasswordSet.Req request) {
+        return mayRenewToken(() -> clusterBlockingStub.userPasswordSet(request));
     }
 
-    public ClusterUserProto.ClusterUser.PasswordAdmin.Res userPasswordAdmin(ClusterUserProto.ClusterUser.PasswordAdmin.Req request) {
-        return mayRenewToken(() -> clusterBlockingStub.userPasswordAdmin(request));
+    public ClusterUserProto.ClusterUserManager.Get.Res userGet(ClusterUserProto.ClusterUserManager.Get.Req request) {
+        return mayRenewToken(() -> clusterBlockingStub.userGet(request));
     }
 
-    public ClusterUserProto.ClusterUser.ExpiryDays.Res userExpiryDays(ClusterUserProto.ClusterUser.ExpiryDays.Req request) {
-        return mayRenewToken(() -> clusterBlockingStub.userExpiryDays(request));
-    }
-
-
-    public ClusterUserProto.ClusterUser.Delete.Res userDelete(ClusterUserProto.ClusterUser.Delete.Req request) {
-        return mayRenewToken(() -> clusterBlockingStub.userDelete(request));
+    public ClusterUserProto.ClusterUser.PasswordUpdate.Res userPasswordUpdate(ClusterUserProto.ClusterUser.PasswordUpdate.Req request) {
+        return mayRenewToken(() -> clusterBlockingStub.userPasswordUpdate(request));
     }
 
     public ClusterDatabaseProto.ClusterDatabaseManager.Get.Res databasesGet(ClusterDatabaseProto.ClusterDatabaseManager.Get.Req request) {

--- a/connection/cluster/ClusterUser.java
+++ b/connection/cluster/ClusterUser.java
@@ -23,25 +23,29 @@ package com.vaticle.typedb.client.connection.cluster;
 
 import com.vaticle.typedb.client.api.user.User;
 
-import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.User.deleteReq;
-import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.User.expiryDaysReq;
-import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.User.passwordAdminReq;
-import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.User.passwordReq;
+import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.User.passwordUpdateReq;
 import static com.vaticle.typedb.client.connection.cluster.ClusterUserManager.SYSTEM_DB;
 
 public class ClusterUser implements User {
 
     private final ClusterClient client;
     private final String username;
+    private final long passwordExpiryDays;
 
-    public ClusterUser(ClusterClient client, String username) {
+    public ClusterUser(ClusterClient client, String username, long passwordExpiryDays) {
         this.client = client;
         this.username = username;
+        this.passwordExpiryDays = passwordExpiryDays;
     }
 
     @Override
     public String username() {
         return username;
+    }
+
+    @Override
+    public long passwordExpiryDays() {
+        return passwordExpiryDays;
     }
 
     @Override

--- a/connection/cluster/ClusterUser.java
+++ b/connection/cluster/ClusterUser.java
@@ -23,6 +23,8 @@ package com.vaticle.typedb.client.connection.cluster;
 
 import com.vaticle.typedb.client.api.user.User;
 
+import java.util.Optional;
+
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.User.passwordUpdateReq;
 import static com.vaticle.typedb.client.connection.cluster.ClusterUserManager.SYSTEM_DB;
 
@@ -30,9 +32,9 @@ public class ClusterUser implements User {
 
     private final ClusterClient client;
     private final String username;
-    private final long passwordExpiryDays;
+    private final Optional<Long> passwordExpiryDays;
 
-    public ClusterUser(ClusterClient client, String username, long passwordExpiryDays) {
+    public ClusterUser(ClusterClient client, String username, Optional<Long> passwordExpiryDays) {
         this.client = client;
         this.username = username;
         this.passwordExpiryDays = passwordExpiryDays;
@@ -44,7 +46,7 @@ public class ClusterUser implements User {
     }
 
     @Override
-    public long passwordExpiryDays() {
+    public Optional<Long> passwordExpiryDays() {
         return passwordExpiryDays;
     }
 

--- a/connection/cluster/ClusterUser.java
+++ b/connection/cluster/ClusterUser.java
@@ -42,8 +42,8 @@ public class ClusterUser implements User {
     }
 
     public static ClusterUser of(ClusterUserProto.User user, ClusterClient client) {
-        if (user.getPasswordExpiryOptCase() ==
-                ClusterUserProto.User.PasswordExpiryOptCase.PASSWORDEXPIRYOPT_NOT_SET) {
+        if (user.getPasswordExpiryCase() ==
+                ClusterUserProto.User.PasswordExpiryCase.PASSWORDEXPIRY_NOT_SET) {
             return new ClusterUser(client, user.getUsername(), Optional.empty());
         }
         else {
@@ -62,11 +62,11 @@ public class ClusterUser implements User {
     }
 
     @Override
-    public void passwordUpdate(String oldPassword, String newPassword) {
+    public void passwordUpdate(String passwordOld, String passwordNew) {
         ClusterClient.FailsafeTask<Void> failsafeTask = client.createFailsafeTask(
                 SYSTEM_DB,
                 parameter -> {
-                    parameter.client().stub().userPasswordUpdate(passwordUpdateReq(username, oldPassword, newPassword));
+                    parameter.client().stub().userPasswordUpdate(passwordUpdateReq(username, passwordOld, passwordNew));
                     return null;
                 }
         );

--- a/connection/cluster/ClusterUser.java
+++ b/connection/cluster/ClusterUser.java
@@ -22,6 +22,7 @@
 package com.vaticle.typedb.client.connection.cluster;
 
 import com.vaticle.typedb.client.api.user.User;
+import com.vaticle.typedb.protocol.ClusterUserProto;
 
 import java.util.Optional;
 
@@ -38,6 +39,16 @@ public class ClusterUser implements User {
         this.client = client;
         this.username = username;
         this.passwordExpiryDays = passwordExpiryDays;
+    }
+
+    public static ClusterUser of(ClusterUserProto.User user, ClusterClient client) {
+        if (user.getPasswordExpiryOptCase() ==
+                ClusterUserProto.User.PasswordExpiryOptCase.PASSWORDEXPIRYOPT_NOT_SET) {
+            return new ClusterUser(client, user.getUsername(), Optional.empty());
+        }
+        else {
+            return new ClusterUser(client, user.getUsername(), Optional.of(user.getPasswordExpiryDays()));
+        }
     }
 
     @Override

--- a/connection/cluster/ClusterUser.java
+++ b/connection/cluster/ClusterUser.java
@@ -45,44 +45,11 @@ public class ClusterUser implements User {
     }
 
     @Override
-    public void password(String oldPassword, String newPassword) {
+    public void passwordUpdate(String oldPassword, String newPassword) {
         ClusterClient.FailsafeTask<Void> failsafeTask = client.createFailsafeTask(
                 SYSTEM_DB,
                 parameter -> {
-                    parameter.client().stub().userPassword(passwordReq(username, oldPassword, newPassword));
-                    return null;
-                }
-        );
-        failsafeTask.runPrimaryReplica();
-    }
-
-    @Override
-    public void passwordAdmin(String password) {
-        ClusterClient.FailsafeTask<Void> failsafeTask = client.createFailsafeTask(
-                SYSTEM_DB,
-                parameter -> {
-                    parameter.client().stub().userPasswordAdmin(passwordAdminReq(username, password));
-                    return null;
-                }
-        );
-        failsafeTask.runPrimaryReplica();
-    }
-
-    @Override
-    public long expiryDays() {
-        ClusterClient.FailsafeTask<Long> failsafeTask = client.createFailsafeTask(
-                SYSTEM_DB,
-                parameter -> parameter.client().stub().userExpiryDays(expiryDaysReq(username)).getExpiryDays()
-        );
-        return failsafeTask.runPrimaryReplica();
-    }
-
-    @Override
-    public void delete() {
-        ClusterClient.FailsafeTask<Void> failsafeTask = client.createFailsafeTask(
-                SYSTEM_DB,
-                parameter -> {
-                    parameter.client().stub().userDelete(deleteReq(username));
+                    parameter.client().stub().userPasswordUpdate(passwordUpdateReq(username, oldPassword, newPassword));
                     return null;
                 }
         );

--- a/connection/cluster/ClusterUser.java
+++ b/connection/cluster/ClusterUser.java
@@ -69,7 +69,7 @@ public class ClusterUser implements User {
     }
 
     @Override
-    public long expiryDays(String username) {
+    public long expiryDays() {
         ClusterClient.FailsafeTask<Long> failsafeTask = client.createFailsafeTask(
                 SYSTEM_DB,
                 parameter -> parameter.client().stub().userExpiryDays(expiryDaysReq(username)).getExpiryDays()

--- a/connection/cluster/ClusterUserManager.java
+++ b/connection/cluster/ClusterUserManager.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLUSTER_USER_DOES_NOT_EXIST;
+import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.User.deleteReq;
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.UserManager.allReq;
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.UserManager.containsReq;
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.UserManager.createReq;
@@ -70,6 +71,18 @@ public class ClusterUserManager implements UserManager {
                 }
         );
 
+        failsafeTask.runPrimaryReplica();
+    }
+
+    @Override
+    public void delete() {
+        ClusterClient.FailsafeTask<Void> failsafeTask = client.createFailsafeTask(
+                SYSTEM_DB,
+                parameter -> {
+                    parameter.client().stub().userDelete(deleteReq(username));
+                    return null;
+                }
+        );
         failsafeTask.runPrimaryReplica();
     }
 

--- a/connection/cluster/ClusterUserManager.java
+++ b/connection/cluster/ClusterUserManager.java
@@ -95,8 +95,8 @@ public class ClusterUserManager implements UserManager {
     }
 
     @Override
-    public ClusterUser get(String username) {
-        ClusterClient.FailsafeTask<ClusterUser> failsafeTask = client.createFailsafeTask(
+    public User get(String username) {
+        ClusterClient.FailsafeTask<User> failsafeTask = client.createFailsafeTask(
                 SYSTEM_DB,
                 (parameter) -> {
                     com.vaticle.typedb.protocol.ClusterUserProto.User user = parameter.client().stub().usersGet(getReq(username)).getUser();

--- a/connection/cluster/ClusterUserManager.java
+++ b/connection/cluster/ClusterUserManager.java
@@ -29,7 +29,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.UserManager.containsReq;
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.UserManager.createReq;
@@ -94,13 +93,7 @@ public class ClusterUserManager implements UserManager {
                     List<ClusterUserProto.User> protoUsers = parameter.client().stub().usersAll(allReq()).getUsersList();
 
                     for (ClusterUserProto.User user: protoUsers) {
-                        if (user.getPasswordExpiryOptCase() ==
-                                ClusterUserProto.User.PasswordExpiryOptCase.PASSWORDEXPIRYOPT_NOT_SET) {
-                            users.add(new ClusterUser(client, user.getUsername(), Optional.empty()));
-                        }
-                        else {
-                            users.add(new ClusterUser(client, user.getUsername(), Optional.of(user.getPasswordExpiryDays())));
-                        }
+                        users.add(ClusterUser.of(user, client));
                     }
 
                     return users;
@@ -116,13 +109,7 @@ public class ClusterUserManager implements UserManager {
                 SYSTEM_DB,
                 (parameter) -> {
                     com.vaticle.typedb.protocol.ClusterUserProto.User user = parameter.client().stub().usersGet(getReq(username)).getUser();
-                    if (user.getPasswordExpiryOptCase() ==
-                            ClusterUserProto.User.PasswordExpiryOptCase.PASSWORDEXPIRYOPT_NOT_SET) {
-                        return new ClusterUser(client, user.getUsername(), Optional.empty());
-                    }
-                    else {
-                        return new ClusterUser(client, user.getUsername(), Optional.of(user.getPasswordExpiryDays()));
-                    }
+                    return ClusterUser.of(user, client);
                 }
         );
         return failsafeTask.runPrimaryReplica();

--- a/connection/cluster/ClusterUserManager.java
+++ b/connection/cluster/ClusterUserManager.java
@@ -85,9 +85,8 @@ public class ClusterUserManager implements UserManager {
     public Set<User> all() {
         ClusterClient.FailsafeTask<Set<User>> failsafeTask = client.createFailsafeTask(
                 SYSTEM_DB,
-                (parameter) -> parameter.client().stub().usersAll(allReq()).getUsersList().stream().map(
-                        (user) -> ClusterUser.of(user, client)).collect(Collectors.toSet()
-                )
+                (parameter) -> parameter.client().stub().usersAll(allReq()).getUsersList().stream()
+                        .map((user) -> ClusterUser.of(user, client)).collect(Collectors.toSet())
         );
         return failsafeTask.runPrimaryReplica();
     }

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -31,8 +31,8 @@ def vaticle_typeql():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/jamesreprise/typedb-common",
-        commit = "1389bc4963e38512b6fbf586c2fca22bc51ae5f0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "775a5b22a34baa47b6ad7cf8dd6bc12a21684efb" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_dependencies():
@@ -45,15 +45,15 @@ def vaticle_dependencies():
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/jamesreprise/typedb-protocol",
-        commit = "8a0e86ea7012bb980adbe36c9f06b2a4cc10c1da", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/vaticle/typedb-protocol",
+        commit = "22c0704c893f362053cc88e68ee2e113384dc03f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/jamesreprise/typedb-behaviour",
-        commit = "8bd11bc57b80efe34df8cd5ca548226feefa0d14", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "04ec1f75cc376524b3cac75af37e1716230845e0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -46,7 +46,7 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/jamesreprise/typedb-protocol",
-        commit = "56759b32e82bc47c19eec9e4715bfd5d3be2626c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "8a0e86ea7012bb980adbe36c9f06b2a4cc10c1da", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -43,11 +43,15 @@ def vaticle_dependencies():
     )
 
 def vaticle_typedb_protocol():
-    git_repository(
+    native.local_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/vaticle/typedb-protocol",
-        tag = "2.14.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        path = "../typedb-protocol",
     )
+#    git_repository(
+#        name = "vaticle_typedb_protocol",
+#        remote = "https://github.com/vaticle/typedb-protocol",
+#        tag = "2.14.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+#    )
 
 def vaticle_typedb_behaviour():
     git_repository(

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -31,8 +31,8 @@ def vaticle_typeql():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "b5475e496002fb8d069e5310b8edbb0dbe723cc5" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/jamesreprise/typedb-common",
+        commit = "1389bc4963e38512b6fbf586c2fca22bc51ae5f0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_dependencies():
@@ -43,21 +43,17 @@ def vaticle_dependencies():
     )
 
 def vaticle_typedb_protocol():
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_protocol",
-        path = "../typedb-protocol",
+        remote = "https://github.com/jamesreprise/typedb-protocol",
+        commit = "56759b32e82bc47c19eec9e4715bfd5d3be2626c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
-#    git_repository(
-#        name = "vaticle_typedb_protocol",
-#        remote = "https://github.com/vaticle/typedb-protocol",
-#        tag = "2.14.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
-#    )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "21ae86ac44e84c7dbb4351a9006b97a555f0a215", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/jamesreprise/typedb-behaviour",
+        commit = "8bd11bc57b80efe34df8cd5ca548226feefa0d14", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/test/behaviour/connection/user/UserSteps.java
+++ b/test/behaviour/connection/user/UserSteps.java
@@ -63,9 +63,14 @@ public class UserSteps {
         getClient().users().create(username, password);
     }
 
-    @Then("user password: {word}, {word}, {word}")
-    public void user_password(String username, String oldPassword, String newPassword) {
-        getClient().users().get(username).password(oldPassword, newPassword);
+    @Then("users delete: {word}")
+    public void users_delete(String username) {
+        getClient().users().delete(username);
+    }
+
+    @Then("user password update: {word}, {word}, {word}")
+    public void user_password_update(String username, String oldPassword, String newPassword) {
+        getClient().users().get(username).passwordUpdate(oldPassword, newPassword);
     }
 
     @Then("user connect: {word}, {word}")
@@ -75,10 +80,5 @@ public class UserSteps {
         try (TypeDBClient.Cluster client = TypeDB.clusterClient(address, credential)) {
             List<Database.Cluster> ignored = client.databases().all();
         }
-    }
-
-    @Then("user delete: {word}")
-    public void user_delete(String username) {
-        getClient().users().get(username).delete();
     }
 }

--- a/test/behaviour/connection/user/UserSteps.java
+++ b/test/behaviour/connection/user/UserSteps.java
@@ -69,8 +69,8 @@ public class UserSteps {
     }
 
     @Then("user password update: {word}, {word}, {word}")
-    public void user_password_update(String username, String oldPassword, String newPassword) {
-        getClient().users().get(username).passwordUpdate(oldPassword, newPassword);
+    public void user_password_update(String username, String passwordOld, String passwordNew) {
+        getClient().users().get(username).passwordUpdate(passwordOld, passwordNew);
     }
 
     @Then("user connect: {word}, {word}")

--- a/test/behaviour/connection/user/UserSteps.java
+++ b/test/behaviour/connection/user/UserSteps.java
@@ -68,6 +68,11 @@ public class UserSteps {
         getClient().users().delete(username);
     }
 
+    @Then("users password set: {word}, {word}")
+    public void user_password_set(String username, String password) {
+        getClient().users().passwordSet(username, password);
+    }
+
     @Then("user password update: {word}, {word}, {word}")
     public void user_password_update(String username, String passwordOld, String passwordNew) {
         getClient().users().get(username).passwordUpdate(passwordOld, passwordNew);

--- a/test/behaviour/connection/user/UserSteps.java
+++ b/test/behaviour/connection/user/UserSteps.java
@@ -63,9 +63,9 @@ public class UserSteps {
         getClient().users().create(username, password);
     }
 
-    @Then("user password: {word}, {word}")
-    public void user_password(String username, String password) {
-        getClient().users().get(username).password(password);
+    @Then("user password: {word}, {word}, {word}")
+    public void user_password(String username, String oldPassword, String newPassword) {
+        getClient().users().get(username).password(oldPassword, newPassword);
     }
 
     @Then("user connect: {word}, {word}")


### PR DESCRIPTION
## What is the goal of this PR?

Add functionality relevant to the changes made in https://github.com/vaticle/typedb-cluster/pull/456:
* Optional password expiry in days for each user.
* The ability for admins to set passwords of other users
* User password update, which requires old and new password

## What are the changes implemented in this PR?

We've added the functionality that is being added in a recent TypeDB Cluster pull request:
* Support updating password now requiring both the old and the new password.
* Add support for retrieving the user password expiry in days. This is optional, depending on whether password expiration is enabled on the server.
* Allow updating password as the admin requiring only a new password.

