### PR TITLE
Bumped @vaticle_typedb_common

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -32,7 +32,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.12.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "b5475e496002fb8d069e5310b8edbb0dbe723cc5" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_dependencies():


### PR DESCRIPTION
## What is the goal of this PR?

Bumped dependency so that changes made in https://github.com/vaticle/typedb-common/commit/b5475e496002fb8d069e5310b8edbb0dbe723cc5 could be propagated to typedb-iam.