### PR TITLE
TypeDB Cluster Authentication Behaviour Tests

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -53,7 +53,7 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel build //...
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors --test_timeout=600
+        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors --test_timeout=1800
     build-dependency:
       image: vaticle-ubuntu-22.04
       command: |
@@ -66,14 +66,14 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel test //test/integration/... --test_output=errors --test_timeout=600
+        bazel test //test/integration/... --test_output=errors --test_timeout=1800
     test-behaviour-connection-core:
       image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //test/behaviour/connection/... --test_output=errors --jobs=1 --test_timeout=600
+        .factory/test-core.sh //test/behaviour/connection/... --test_output=errors --jobs=1 --test_timeout=1800
     # TODO: delete --jobs=1 if we fix the issue with excess memory usage
     test-behaviour-connection-cluster:
       image: vaticle-ubuntu-22.04
@@ -81,7 +81,7 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cluster.sh //test/behaviour/connection/... --test_output=errors --jobs=1 --test_timeout=600
+        .factory/test-cluster.sh //test/behaviour/connection/... --test_output=errors --jobs=1 --test_timeout=1800
     # TODO: delete --jobs=1 if we fix the issue with excess memory usage
     test-behaviour-concept-core:
       image: vaticle-ubuntu-22.04
@@ -89,7 +89,7 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //test/behaviour/concept/... --test_output=errors --test_timeout=600
+        .factory/test-core.sh //test/behaviour/concept/... --test_output=errors --test_timeout=1800
 #    test-behaviour-concept-cluster:
 #      image: vaticle-ubuntu-22.04
 #      command: |
@@ -103,8 +103,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //test/behaviour/typeql/language/match/... --test_output=errors --test_timeout=600
-        .factory/test-core.sh //test/behaviour/typeql/language/get/... --test_output=errors --test_timeout=600
+        .factory/test-core.sh //test/behaviour/typeql/language/match/... --test_output=errors --test_timeout=1800
+        .factory/test-core.sh //test/behaviour/typeql/language/get/... --test_output=errors --test_timeout=1800
 #    test-behaviour-match-cluster:
 #      image: vaticle-ubuntu-22.04
 #      command: |
@@ -119,34 +119,34 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //test/behaviour/typeql/language/insert/... --test_output=errors --test_timeout=600
-        .factory/test-core.sh //test/behaviour/typeql/language/delete/... --test_output=errors --test_timeout=600
-        .factory/test-core.sh //test/behaviour/typeql/language/update/... --test_output=errors --test_timeout=600
+        .factory/test-core.sh //test/behaviour/typeql/language/insert/... --test_output=errors --test_timeout=1800
+        .factory/test-core.sh //test/behaviour/typeql/language/delete/... --test_output=errors --test_timeout=1800
+        .factory/test-core.sh //test/behaviour/typeql/language/update/... --test_output=errors --test_timeout=1800
     test-behaviour-writable-cluster:
       image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cluster.sh //test/behaviour/typeql/language/insert/... --test_output=errors --test_timeout=600
-        .factory/test-cluster.sh //test/behaviour/typeql/language/delete/... --test_output=errors --test_timeout=600
-        .factory/test-cluster.sh //test/behaviour/typeql/language/update/... --test_output=errors --test_timeout=600
+        .factory/test-cluster.sh //test/behaviour/typeql/language/insert/... --test_output=errors --test_timeout=1800
+        .factory/test-cluster.sh //test/behaviour/typeql/language/delete/... --test_output=errors --test_timeout=1800
+        .factory/test-cluster.sh //test/behaviour/typeql/language/update/... --test_output=errors --test_timeout=1800
     test-behaviour-definable-core:
       image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //test/behaviour/typeql/language/define/... --test_output=errors --test_timeout=600
-        .factory/test-core.sh //test/behaviour/typeql/language/undefine/... --test_output=errors --test_timeout=600
+        .factory/test-core.sh //test/behaviour/typeql/language/define/... --test_output=errors --test_timeout=1800
+        .factory/test-core.sh //test/behaviour/typeql/language/undefine/... --test_output=errors --test_timeout=1800
     test-behaviour-definable-cluster:
       image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cluster.sh //test/behaviour/typeql/language/define/... --test_output=errors --test_timeout=600
-        .factory/test-cluster.sh //test/behaviour/typeql/language/undefine/... --test_output=errors --test_timeout=600
+        .factory/test-cluster.sh //test/behaviour/typeql/language/define/... --test_output=errors --test_timeout=1800
+        .factory/test-cluster.sh //test/behaviour/typeql/language/undefine/... --test_output=errors --test_timeout=1800
     deploy-maven-snapshot:
       image: vaticle-ubuntu-22.04
       dependencies: [

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -75,13 +75,13 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-core.sh //test/behaviour/connection/... --test_output=errors --jobs=1
     # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-#    test-behaviour-connection-cluster:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cluster.sh //test/behaviour/connection/... --test_output=errors --jobs=1
+    test-behaviour-connection-cluster:
+      image: vaticle-ubuntu-22.04
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cluster.sh //test/behaviour/connection/... --test_output=errors --jobs=1
     # TODO: delete --jobs=1 if we fix the issue with excess memory usage
     test-behaviour-concept-core:
       image: vaticle-ubuntu-22.04

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -53,7 +53,7 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel build //...
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
+        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors --test_timeout=600
     build-dependency:
       image: vaticle-ubuntu-22.04
       command: |
@@ -66,14 +66,14 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel test //test/integration/... --test_output=errors
+        bazel test //test/integration/... --test_output=errors --test_timeout=600
     test-behaviour-connection-core:
       image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //test/behaviour/connection/... --test_output=errors --jobs=1
+        .factory/test-core.sh //test/behaviour/connection/... --test_output=errors --jobs=1 --test_timeout=600
     # TODO: delete --jobs=1 if we fix the issue with excess memory usage
     test-behaviour-connection-cluster:
       image: vaticle-ubuntu-22.04
@@ -81,7 +81,7 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cluster.sh //test/behaviour/connection/... --test_output=errors --jobs=1
+        .factory/test-cluster.sh //test/behaviour/connection/... --test_output=errors --jobs=1 --test_timeout=600
     # TODO: delete --jobs=1 if we fix the issue with excess memory usage
     test-behaviour-concept-core:
       image: vaticle-ubuntu-22.04
@@ -89,7 +89,7 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //test/behaviour/concept/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/concept/... --test_output=errors --test_timeout=600
 #    test-behaviour-concept-cluster:
 #      image: vaticle-ubuntu-22.04
 #      command: |
@@ -103,8 +103,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //test/behaviour/typeql/language/match/... --test_output=errors
-        .factory/test-core.sh //test/behaviour/typeql/language/get/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/typeql/language/match/... --test_output=errors --test_timeout=600
+        .factory/test-core.sh //test/behaviour/typeql/language/get/... --test_output=errors --test_timeout=600
 #    test-behaviour-match-cluster:
 #      image: vaticle-ubuntu-22.04
 #      command: |
@@ -119,34 +119,34 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //test/behaviour/typeql/language/insert/... --test_output=errors
-        .factory/test-core.sh //test/behaviour/typeql/language/delete/... --test_output=errors
-        .factory/test-core.sh //test/behaviour/typeql/language/update/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/typeql/language/insert/... --test_output=errors --test_timeout=600
+        .factory/test-core.sh //test/behaviour/typeql/language/delete/... --test_output=errors --test_timeout=600
+        .factory/test-core.sh //test/behaviour/typeql/language/update/... --test_output=errors --test_timeout=600
     test-behaviour-writable-cluster:
       image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cluster.sh //test/behaviour/typeql/language/insert/... --test_output=errors
-        .factory/test-cluster.sh //test/behaviour/typeql/language/delete/... --test_output=errors
-        .factory/test-cluster.sh //test/behaviour/typeql/language/update/... --test_output=errors
+        .factory/test-cluster.sh //test/behaviour/typeql/language/insert/... --test_output=errors --test_timeout=600
+        .factory/test-cluster.sh //test/behaviour/typeql/language/delete/... --test_output=errors --test_timeout=600
+        .factory/test-cluster.sh //test/behaviour/typeql/language/update/... --test_output=errors --test_timeout=600
     test-behaviour-definable-core:
       image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //test/behaviour/typeql/language/define/... --test_output=errors
-        .factory/test-core.sh //test/behaviour/typeql/language/undefine/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/typeql/language/define/... --test_output=errors --test_timeout=600
+        .factory/test-core.sh //test/behaviour/typeql/language/undefine/... --test_output=errors --test_timeout=600
     test-behaviour-definable-cluster:
       image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cluster.sh //test/behaviour/typeql/language/define/... --test_output=errors
-        .factory/test-cluster.sh //test/behaviour/typeql/language/undefine/... --test_output=errors
+        .factory/test-cluster.sh //test/behaviour/typeql/language/define/... --test_output=errors --test_timeout=600
+        .factory/test-cluster.sh //test/behaviour/typeql/language/undefine/... --test_output=errors --test_timeout=600
     deploy-maven-snapshot:
       image: vaticle-ubuntu-22.04
       dependencies: [

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -60,6 +60,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Client(15, "The user '%s' does not exist.");
         public static final ErrorMessage CLUSTER_TOKEN_CREDENTIAL_INVALID =
                 new Client(16, "Invalid token credential.");
+        public static final ErrorMessage CLUSTER_PASSWORD_CREDENTIAL_EXPIRED =
+                new Client(17, "Expired password credential.");
 
         private static final String codePrefix = "CLI";
         private static final String messagePrefix = "Client Error";

--- a/common/exception/TypeDBClientException.java
+++ b/common/exception/TypeDBClientException.java
@@ -31,6 +31,7 @@ public class TypeDBClientException extends RuntimeException {
     // TODO: propagate exception from the server side in a less-brittle way
     private static final String CLUSTER_REPLICA_NOT_PRIMARY_ERROR_CODE = "[RPL01]";
     private static final String CLUSTER_TOKEN_CREDENTIAL_INVALID_ERROR_CODE = "[CLS08]";
+    private static final String CLUSTER_PASSWORD_CREDENTIAL_EXPIRED_ERROR_CODE = "[CLS10]";
 
     @Nullable
     private final ErrorMessage errorMessage;
@@ -53,6 +54,8 @@ public class TypeDBClientException extends RuntimeException {
             return new TypeDBClientException(ErrorMessage.Client.CLUSTER_REPLICA_NOT_PRIMARY);
         } else if (isTokenCredentialInvalid(sre)) {
             return new TypeDBClientException(ErrorMessage.Client.CLUSTER_TOKEN_CREDENTIAL_INVALID);
+         } else if (isPasswordCredentialExpired(sre)) {
+            return new TypeDBClientException(ErrorMessage.Client.CLUSTER_PASSWORD_CREDENTIAL_EXPIRED);
         } else {
             return new TypeDBClientException(sre.getStatus().getDescription(), sre);
         }
@@ -77,6 +80,11 @@ public class TypeDBClientException extends RuntimeException {
                 statusRuntimeException.getStatus().getDescription().contains(CLUSTER_TOKEN_CREDENTIAL_INVALID_ERROR_CODE);
     }
 
+    private static boolean isPasswordCredentialExpired(StatusRuntimeException statusRuntimeException) {
+        return statusRuntimeException.getStatus().getCode() == Status.Code.UNAUTHENTICATED &&
+                statusRuntimeException.getStatus().getDescription() != null &&
+                statusRuntimeException.getStatus().getDescription().contains(CLUSTER_PASSWORD_CREDENTIAL_EXPIRED_ERROR_CODE);
+    }
     public String getName() {
         return this.getClass().getName();
     }

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "3d7d8095660cf8b929c5303976938b9dabbbf96a",
+        commit = "de6c2e8054b5c0fc6d8bc6e0071bc1a7c276efe6",
     )
 
 def vaticle_typedb_cluster_artifact():
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifact():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "2dc738a901f93d2f8912fd09911eaef95398c181",
+        commit = "302c0db2a29d515b75b7ef219ddfe3b85edbf9c8",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifact():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "2b2b7c8c963d313e97c082a4cead25e38533c5f7",
+        commit = "2dc738a901f93d2f8912fd09911eaef95398c181",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "ab258158efd6f608fe6df2fb4ebf6e5d9f710765",
+        commit = "3d7d8095660cf8b929c5303976938b9dabbbf96a",
     )
 
 def vaticle_typedb_cluster_artifact():
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifact():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "ff021f6201db41c1f81af1dfec5c90b8b9803efe",
+        commit = "2b2b7c8c963d313e97c082a4cead25e38533c5f7",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -29,11 +29,15 @@ def vaticle_typeql():
     )
 
 def vaticle_typedb_common():
-    git_repository(
+    native.local_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "01420b86213dc931ff97188daa06b9ecf06f3932",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        path = "../typedb-common",
     )
+#    git_repository(
+#        name = "vaticle_typedb_common",
+#        remote = "https://github.com/vaticle/typedb-common",
+#        commit = "01420b86213dc931ff97188daa06b9ecf06f3932",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+#    )
 
 def vaticle_dependencies():
     git_repository(

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -29,15 +29,15 @@ def vaticle_typeql():
     )
 
 def vaticle_typedb_common():
-    native.local_repository(
-        name = "vaticle_typedb_common",
-        path = "../typedb-common",
-    )
-#    git_repository(
+#    native.local_repository(
 #        name = "vaticle_typedb_common",
-#        remote = "https://github.com/vaticle/typedb-common",
-#        commit = "01420b86213dc931ff97188daa06b9ecf06f3932",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+#        path = "../typedb-common",
 #    )
+    git_repository(
+        name = "vaticle_typedb_common",
+        remote = "https://github.com/jamesreprise/typedb-common",
+        commit = "25bfd47164cab06d2a07060faee82d40a710caaa",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+    )
 
 def vaticle_dependencies():
     git_repository(

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -29,14 +29,10 @@ def vaticle_typeql():
     )
 
 def vaticle_typedb_common():
-#    git_repository(
-#        name = "vaticle_typedb_common",
-#        remote = "https://github.com/vaticle/typedb-common",
-#        tag = "2.16.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
-#    )
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_common",
-        path = "../typedb-common",
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "01420b86213dc931ff97188daa06b9ecf06f3932" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_dependencies():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,36 +25,37 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        tag = "2.14.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        tag = "2.14.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "01420b86213dc931ff97188daa06b9ecf06f3932" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "01420b86213dc931ff97188daa06b9ecf06f3932",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "6a8c31f57b8f7e10d63f00ef709f80c301aaedaf", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "6a8c31f57b8f7e10d63f00ef709f80c301aaedaf",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
-        commit = "a22d4eb77c799f93c2898f7e2ef6a9b52ab716f1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "a22d4eb77c799f93c2898f7e2ef6a9b52ab716f1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/jamesreprise/typedb-behaviour",
-        commit = "572b36caf06473b78d59ed7af52772074b8a2f76", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "572b36caf06473b78d59ed7af52772074b8a2f76",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
+
 #    native.local_repository(
 #        name = "vaticle_typedb_behaviour",
 #        path = "../typedb-behaviour",
@@ -64,5 +65,5 @@ def vaticle_factory_tracing():
     git_repository(
         name = "vaticle_factory_tracing",
         remote = "https://github.com/vaticle/factory-tracing",
-        tag = "2.12.0"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
+        tag = "2.12.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -32,7 +32,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/jamesreprise/typedb-common",
-        commit = "25bfd47164cab06d2a07060faee82d40a710caaa", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "a5d4ddf53e0f3bed3d73fa10137edf1a3732595e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_dependencies():
@@ -46,7 +46,7 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
-        commit = "a22d4eb77c799f93c2898f7e2ef6a9b52ab716f1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "a8c2bd79c4e440d4682e68bb15b4578456eefd2a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -29,10 +29,14 @@ def vaticle_typeql():
     )
 
 def vaticle_typedb_common():
-    git_repository(
+#    git_repository(
+#        name = "vaticle_typedb_common",
+#        remote = "https://github.com/vaticle/typedb-common",
+#        tag = "2.16.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+#    )
+    native.local_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "01420b86213dc931ff97188daa06b9ecf06f3932" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        path = "../typedb-common",
     )
 
 def vaticle_dependencies():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -50,10 +50,14 @@ def vaticle_typedb_protocol():
     )
 
 def vaticle_typedb_behaviour():
-    git_repository(
+#    git_repository(
+#        name = "vaticle_typedb_behaviour",
+#        remote = "https://github.com/vaticle/typedb-behaviour",
+#        commit = "04ec1f75cc376524b3cac75af37e1716230845e0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+#    )
+    native.local_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "ff4f58b4db2200b907c60b28a2b8ee661449e9c0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        path = "../typedb-behaviour",
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -53,9 +53,10 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/jamesreprise/typedb-behaviour",
-        commit = "572b36caf06473b78d59ed7af52772074b8a2f76",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "dde2d881805f12faad40b1bdc056732922c47b76",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
+#
 #    native.local_repository(
 #        name = "vaticle_typedb_behaviour",
 #        path = "../typedb-behaviour",

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -46,14 +46,14 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
-        commit = "a8c2bd79c4e440d4682e68bb15b4578456eefd2a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "a22d4eb77c799f93c2898f7e2ef6a9b52ab716f1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/jamesreprise/typedb-behaviour",
-        commit = "dde2d881805f12faad40b1bdc056732922c47b76" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "a8c2bd79c4e440d4682e68bb15b4578456eefd2a" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,50 +25,40 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        tag = "2.14.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        tag = "2.14.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
-#    native.local_repository(
-#        name = "vaticle_typedb_common",
-#        path = "../typedb-common",
-#    )
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/jamesreprise/typedb-common",
-        commit = "25bfd47164cab06d2a07060faee82d40a710caaa",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "25bfd47164cab06d2a07060faee82d40a710caaa", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "6a8c31f57b8f7e10d63f00ef709f80c301aaedaf",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "6a8c31f57b8f7e10d63f00ef709f80c301aaedaf", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
-        commit = "a22d4eb77c799f93c2898f7e2ef6a9b52ab716f1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "a22d4eb77c799f93c2898f7e2ef6a9b52ab716f1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/jamesreprise/typedb-behaviour",
-        commit = "dde2d881805f12faad40b1bdc056732922c47b76",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "dde2d881805f12faad40b1bdc056732922c47b76" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
-
-#
-#    native.local_repository(
-#        name = "vaticle_typedb_behaviour",
-#        path = "../typedb-behaviour",
-#    )
 
 def vaticle_factory_tracing():
     git_repository(
         name = "vaticle_factory_tracing",
         remote = "https://github.com/vaticle/factory-tracing",
-        tag = "2.12.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
+        tag = "2.12.0"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -50,15 +50,15 @@ def vaticle_typedb_protocol():
     )
 
 def vaticle_typedb_behaviour():
-#    git_repository(
-#        name = "vaticle_typedb_behaviour",
-#        remote = "https://github.com/vaticle/typedb-behaviour",
-#        commit = "04ec1f75cc376524b3cac75af37e1716230845e0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
-#    )
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_behaviour",
-        path = "../typedb-behaviour",
+        remote = "https://github.com/jamesreprise/typedb-behaviour",
+        commit = "572b36caf06473b78d59ed7af52772074b8a2f76", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
+#    native.local_repository(
+#        name = "vaticle_typedb_behaviour",
+#        path = "../typedb-behaviour",
+#    )
 
 def vaticle_factory_tracing():
     git_repository(

--- a/test/behaviour/BehaviourTest.java
+++ b/test/behaviour/BehaviourTest.java
@@ -33,7 +33,6 @@ public abstract class BehaviourTest {
 
     @AfterClass
     public static void afterAll() {
-        TypeDBRunner server = TypeDBSingleton.getTypeDBRunner();
-        if (server != null) server.stop();
+        TypeDBSingleton.deleteTypeDBRunner();
     }
 }

--- a/test/behaviour/BehaviourTest.java
+++ b/test/behaviour/BehaviourTest.java
@@ -34,7 +34,6 @@ public abstract class BehaviourTest {
     @AfterClass
     public static void afterAll() {
         TypeDBRunner server = TypeDBSingleton.getTypeDBRunner();
-        assert server != null;
-        server.stop();
+        if (server != null) server.stop();
     }
 }

--- a/test/behaviour/BehaviourTest.java
+++ b/test/behaviour/BehaviourTest.java
@@ -21,7 +21,6 @@
 
 package com.vaticle.typedb.client.test.behaviour;
 
-import com.vaticle.typedb.common.test.TypeDBRunner;
 import com.vaticle.typedb.common.test.TypeDBSingleton;
 import org.junit.AfterClass;
 

--- a/test/behaviour/connection/BUILD
+++ b/test/behaviour/connection/BUILD
@@ -66,6 +66,7 @@ java_library(
         ":steps-base",
         "//:client-java",
         "//api:api",
+        "//test/behaviour/util:util",
         "@vaticle_typedb_common//test:typedb-runner",
 
         # External dependencies from Maven

--- a/test/behaviour/connection/ConnectionStepsBase.java
+++ b/test/behaviour/connection/ConnectionStepsBase.java
@@ -80,14 +80,6 @@ public abstract class ConnectionStepsBase {
                 isBeforeAllRan = true;
             }
         }
-        TypeDBRunner runner = TypeDBSingleton.getTypeDBRunner();
-        runner.start();
-
-        String address = runner.address();
-        assertNotNull(address);
-        TypeDBClient client = createTypeDBClient(address);
-
-        client.databases().all().forEach(Database::delete);
         sessionOptions = createOptions().infer(true);
         transactionOptions = createOptions().infer(true);
 

--- a/test/behaviour/connection/ConnectionStepsBase.java
+++ b/test/behaviour/connection/ConnectionStepsBase.java
@@ -25,7 +25,6 @@ import com.vaticle.typedb.client.api.TypeDBClient;
 import com.vaticle.typedb.client.api.TypeDBOptions;
 import com.vaticle.typedb.client.api.TypeDBSession;
 import com.vaticle.typedb.client.api.TypeDBTransaction;
-import com.vaticle.typedb.common.test.TypeDBRunner;
 import com.vaticle.typedb.common.test.TypeDBSingleton;
 
 import java.util.ArrayList;

--- a/test/behaviour/connection/ConnectionStepsBase.java
+++ b/test/behaviour/connection/ConnectionStepsBase.java
@@ -42,7 +42,6 @@ import static com.vaticle.typedb.common.collection.Collections.map;
 import static com.vaticle.typedb.common.collection.Collections.pair;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public abstract class ConnectionStepsBase {
@@ -78,13 +77,16 @@ public abstract class ConnectionStepsBase {
                 isBeforeAllRan = true;
             }
         }
-        assertNull(client);
         String address = TypeDBSingleton.getTypeDBRunner().address();
         assertNotNull(address);
-        client = createTypeDBClient(address);
+        TypeDBClient client = createTypeDBClient(address);
         client.databases().all().forEach(Database::delete);
         sessionOptions = createOptions().infer(true);
         transactionOptions = createOptions().infer(true);
+        client.close();
+        assertFalse(client.isOpen());
+        client = null;
+        TypeDBSingleton.getTypeDBRunner().stop();
         System.out.println("ConnectionSteps.before");
     }
 
@@ -109,6 +111,9 @@ public abstract class ConnectionStepsBase {
         sessionsToTransactions.clear();
         sessionsToTransactionsParallel.clear();
         sessionsParallelToTransactionsParallel.clear();
+        String address = TypeDBSingleton.getTypeDBRunner().address();
+        assertNotNull(address);
+        TypeDBClient client = createTypeDBClient(address);
         client.databases().all().forEach(Database::delete);
         client.close();
         assertFalse(client.isOpen());
@@ -128,6 +133,7 @@ public abstract class ConnectionStepsBase {
     void connection_does_not_have_any_database() {
         assertNotNull(client);
         assertTrue(client.isOpen());
+        assertTrue(client.databases().all().isEmpty());
     }
 
 }

--- a/test/behaviour/connection/ConnectionStepsBase.java
+++ b/test/behaviour/connection/ConnectionStepsBase.java
@@ -123,6 +123,7 @@ public abstract class ConnectionStepsBase {
         client.close();
         assertFalse(client.isOpen());
         client = null;
+        TypeDBSingleton.getTypeDBRunner().stop();
         System.out.println("ConnectionSteps.after");
     }
 

--- a/test/behaviour/connection/ConnectionStepsBase.java
+++ b/test/behaviour/connection/ConnectionStepsBase.java
@@ -26,6 +26,7 @@ import com.vaticle.typedb.client.api.TypeDBOptions;
 import com.vaticle.typedb.client.api.TypeDBSession;
 import com.vaticle.typedb.client.api.TypeDBTransaction;
 import com.vaticle.typedb.client.api.database.Database;
+import com.vaticle.typedb.common.test.TypeDBRunner;
 import com.vaticle.typedb.common.test.TypeDBSingleton;
 
 import java.util.ArrayList;
@@ -77,16 +78,20 @@ public abstract class ConnectionStepsBase {
                 isBeforeAllRan = true;
             }
         }
-        String address = TypeDBSingleton.getTypeDBRunner().address();
+        TypeDBRunner runner = TypeDBSingleton.getTypeDBRunner();
+        runner.start();
+
+        String address = runner.address();
         assertNotNull(address);
         TypeDBClient client = createTypeDBClient(address);
+
         client.databases().all().forEach(Database::delete);
         sessionOptions = createOptions().infer(true);
         transactionOptions = createOptions().infer(true);
+
         client.close();
         assertFalse(client.isOpen());
         client = null;
-        TypeDBSingleton.getTypeDBRunner().stop();
         System.out.println("ConnectionSteps.before");
     }
 

--- a/test/behaviour/connection/ConnectionStepsBase.java
+++ b/test/behaviour/connection/ConnectionStepsBase.java
@@ -124,6 +124,7 @@ public abstract class ConnectionStepsBase {
         assertFalse(client.isOpen());
         client = null;
         TypeDBSingleton.getTypeDBRunner().stop();
+        TypeDBSingleton.getTypeDBRunner().destroy();
         TypeDBSingleton.setTypeDBRunner(null);
         System.out.println("ConnectionSteps.after");
     }

--- a/test/behaviour/connection/ConnectionStepsBase.java
+++ b/test/behaviour/connection/ConnectionStepsBase.java
@@ -29,7 +29,6 @@ import com.vaticle.typedb.client.api.database.Database;
 import com.vaticle.typedb.common.test.TypeDBRunner;
 import com.vaticle.typedb.common.test.TypeDBSingleton;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,7 +36,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
@@ -70,7 +68,13 @@ public abstract class ConnectionStepsBase {
         return sessionsToTransactions.get(sessions.get(0)).get(0);
     }
 
-    abstract void beforeAll();
+    void beforeAll() {
+        TypeDBRunner runner = TypeDBSingleton.getTypeDBRunner();
+        if (runner != null) {
+            TypeDBSingleton.getTypeDBRunner().stop();
+            TypeDBSingleton.setTypeDBRunner(null);
+        }
+    }
 
     void before() {
         if (!isBeforeAllRan) {
@@ -82,6 +86,11 @@ public abstract class ConnectionStepsBase {
         }
         sessionOptions = createOptions().infer(true);
         transactionOptions = createOptions().infer(true);
+        TypeDBRunner runner = TypeDBSingleton.getTypeDBRunner();
+        if (runner != null) {
+            runner.stop();
+            TypeDBSingleton.setTypeDBRunner(null);
+        }
 
         System.out.println("ConnectionSteps.before");
     }
@@ -115,6 +124,7 @@ public abstract class ConnectionStepsBase {
         assertFalse(client.isOpen());
         client = null;
         TypeDBSingleton.getTypeDBRunner().stop();
+        TypeDBSingleton.setTypeDBRunner(null);
         System.out.println("ConnectionSteps.after");
     }
 

--- a/test/behaviour/connection/ConnectionStepsBase.java
+++ b/test/behaviour/connection/ConnectionStepsBase.java
@@ -29,6 +29,7 @@ import com.vaticle.typedb.client.api.database.Database;
 import com.vaticle.typedb.common.test.TypeDBRunner;
 import com.vaticle.typedb.common.test.TypeDBSingleton;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -36,6 +37,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
@@ -89,9 +91,6 @@ public abstract class ConnectionStepsBase {
         sessionOptions = createOptions().infer(true);
         transactionOptions = createOptions().infer(true);
 
-        client.close();
-        assertFalse(client.isOpen());
-        client = null;
         System.out.println("ConnectionSteps.before");
     }
 
@@ -131,6 +130,8 @@ public abstract class ConnectionStepsBase {
 
     abstract TypeDBOptions createOptions();
 
+    abstract void open_connection();
+
     void connection_has_been_opened() {
         assertNotNull(client);
         assertTrue(client.isOpen());
@@ -141,5 +142,4 @@ public abstract class ConnectionStepsBase {
         assertTrue(client.isOpen());
         assertTrue(client.databases().all().isEmpty());
     }
-
 }

--- a/test/behaviour/connection/ConnectionStepsCluster.java
+++ b/test/behaviour/connection/ConnectionStepsCluster.java
@@ -38,8 +38,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.vaticle.typedb.client.test.behaviour.util.Util.assertThrows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class ConnectionStepsCluster extends ConnectionStepsBase {
 

--- a/test/behaviour/connection/ConnectionStepsCluster.java
+++ b/test/behaviour/connection/ConnectionStepsCluster.java
@@ -25,28 +25,38 @@ import com.vaticle.typedb.client.TypeDB;
 import com.vaticle.typedb.client.api.TypeDBClient;
 import com.vaticle.typedb.client.api.TypeDBCredential;
 import com.vaticle.typedb.client.api.TypeDBOptions;
+import com.vaticle.typedb.common.test.TypeDBRunner;
 import com.vaticle.typedb.common.test.cluster.TypeDBClusterRunner;
 import com.vaticle.typedb.common.test.TypeDBSingleton;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
 
-import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.concurrent.TimeoutException;
+import java.util.Map;
+
+import static com.vaticle.typedb.client.test.behaviour.util.Util.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class ConnectionStepsCluster extends ConnectionStepsBase {
 
     @Override
     void beforeAll() {
         TypeDBClusterRunner cluster = TypeDBClusterRunner.create(Paths.get("."), 1);
-        cluster.start();
         TypeDBSingleton.setTypeDBRunner(cluster);
     }
 
     @Before
     public synchronized void before() {
         super.before();
+        TypeDBRunner cluster = TypeDBSingleton.getTypeDBRunner();
+        cluster.start();
+        TypeDBClient.Cluster clusterClient = createTypeDBClient(cluster.address()).asCluster();
+        clusterClient.users().all().stream().filter(user -> !user.username().equals("admin"))
+                .forEach(user -> clusterClient.users().delete(user.username()));
+        cluster.stop();
     }
 
     @After
@@ -56,7 +66,11 @@ public class ConnectionStepsCluster extends ConnectionStepsBase {
 
     @Override
     TypeDBClient createTypeDBClient(String address) {
-        return TypeDB.clusterClient(address, new TypeDBCredential("admin", "password", false));
+        return createTypeDBClient(address, "admin", "password", false);
+    }
+
+    TypeDBClient createTypeDBClient(String address, String username, String password, boolean tlsEnabled) {
+        return TypeDB.clusterClient(address, new TypeDBCredential(username, password, tlsEnabled));
     }
 
     @Override
@@ -69,9 +83,47 @@ public class ConnectionStepsCluster extends ConnectionStepsBase {
         super.connection_has_been_opened();
     }
 
+    @Given("connected as user {word}")
+    public void connected_as_user(String user) {
+        assertNotNull(client);
+        assertEquals(client.asCluster().username(), user);
+    }
+
+    @Given("cluster has configuration")
+    public void cluster_has_configuration(Map<String, String> serverOpts) {
+        TypeDBClusterRunner clusterRunner = TypeDBClusterRunner.create(Paths.get("."), 1, serverOpts);
+        TypeDBSingleton.setTypeDBRunner(clusterRunner);
+    }
+
+    @When("cluster stops")
+    public void cluster_stops() {
+        TypeDBSingleton.getTypeDBRunner().stop();
+    }
+
+    @When("cluster starts")
+    public void cluster_starts() {
+        TypeDBRunner runner = TypeDBSingleton.getTypeDBRunner();
+        if (runner != null) {
+            runner.start();
+        } else {
+            TypeDBClusterRunner clusterRunner = TypeDBClusterRunner.create(Paths.get("."), 1);
+            TypeDBSingleton.setTypeDBRunner(clusterRunner);
+            clusterRunner.start();
+        }
+    }
+
+    @When("connect as user {word} with password {word}")
+    public void connect_as_user_with_password(String user, String password) {
+        client = createTypeDBClient(TypeDBSingleton.getTypeDBRunner().address(), user, password, false);
+    }
+
+    @When("connect as user {word} with password {word}; throws exception")
+    public void connect_as_user_with_password_throws_exception(String user, String password) {
+        assertThrows(() -> createTypeDBClient(TypeDBSingleton.getTypeDBRunner().address(), user, password, false));
+    }
+
     @Given("connection does not have any database")
     public void connection_does_not_have_any_database() {
         super.connection_does_not_have_any_database();
     }
-
 }

--- a/test/behaviour/connection/ConnectionStepsCluster.java
+++ b/test/behaviour/connection/ConnectionStepsCluster.java
@@ -44,13 +44,14 @@ import static org.junit.Assert.assertNotNull;
 public class ConnectionStepsCluster extends ConnectionStepsBase {
 
     @Override
-    void beforeAll() {
-        TypeDBSingleton.getTypeDBRunner().stop();
-        TypeDBSingleton.setTypeDBRunner(null);
+    public void beforeAll() {
+        super.beforeAll();
     }
 
     @Before
-    public synchronized void before() {}
+    public synchronized void before() {
+        super.before();
+    }
 
     @After
     public synchronized void after() {

--- a/test/behaviour/connection/ConnectionStepsCluster.java
+++ b/test/behaviour/connection/ConnectionStepsCluster.java
@@ -91,7 +91,7 @@ public class ConnectionStepsCluster extends ConnectionStepsBase {
 
     @Given("typedb has configuration")
     public void typedb_has_configuration(Map<String, String> map) {
-        TypeDBSingleton.setTypeDBRunner(null);
+        TypeDBSingleton.deleteTypeDBRunner();
         Map<String, String> serverOpts = new HashMap<>();
         for (Map.Entry<String, String> entry : map.entrySet()) {
             serverOpts.put("--" + entry.getKey(), entry.getValue());

--- a/test/behaviour/connection/ConnectionStepsCluster.java
+++ b/test/behaviour/connection/ConnectionStepsCluster.java
@@ -83,12 +83,6 @@ public class ConnectionStepsCluster extends ConnectionStepsBase {
         super.connection_has_been_opened();
     }
 
-    @Given("connected as user {word}")
-    public void connected_as_user(String username) {
-        assertNotNull(client);
-        assertEquals(client.asCluster().user().username(), username);
-    }
-
     @Given("typedb has configuration")
     public void typedb_has_configuration(Map<String, String> map) {
         TypeDBSingleton.deleteTypeDBRunner();

--- a/test/behaviour/connection/ConnectionStepsCluster.java
+++ b/test/behaviour/connection/ConnectionStepsCluster.java
@@ -29,7 +29,6 @@ import com.vaticle.typedb.common.test.TypeDBRunner;
 import com.vaticle.typedb.common.test.cluster.TypeDBClusterRunner;
 import com.vaticle.typedb.common.test.TypeDBSingleton;
 import io.cucumber.java.After;
-import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.When;
 
@@ -110,7 +109,7 @@ public class ConnectionStepsCluster extends ConnectionStepsBase {
         client = createTypeDBClient(TypeDBSingleton.getTypeDBRunner().address(), username, password, false);
     }
 
-    @When("disconnect current user")
+    @When("user disconnect")
     public void disconnect_current_user() {
         client.close();
         client = null;

--- a/test/behaviour/connection/ConnectionStepsCore.java
+++ b/test/behaviour/connection/ConnectionStepsCore.java
@@ -85,7 +85,9 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
                 TypeDBCoreRunner typeDBCoreRunner = new TypeDBCoreRunner();
                 TypeDBSingleton.setTypeDBRunner(typeDBCoreRunner);
                 typeDBCoreRunner.start();
-            } catch (Exception e) {}
+            } catch (InterruptedException | java.util.concurrent.TimeoutException | java.io.IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/test/behaviour/connection/ConnectionStepsCore.java
+++ b/test/behaviour/connection/ConnectionStepsCore.java
@@ -32,9 +32,6 @@ import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.When;
 
-import java.io.IOException;
-import java.util.concurrent.TimeoutException;
-
 public class ConnectionStepsCore extends ConnectionStepsBase {
     private TypeDBCoreRunner server;
 

--- a/test/behaviour/connection/ConnectionStepsCore.java
+++ b/test/behaviour/connection/ConnectionStepsCore.java
@@ -24,11 +24,13 @@ package com.vaticle.typedb.client.test.behaviour.connection;
 import com.vaticle.typedb.client.TypeDB;
 import com.vaticle.typedb.client.api.TypeDBClient;
 import com.vaticle.typedb.client.api.TypeDBOptions;
+import com.vaticle.typedb.common.test.TypeDBRunner;
 import com.vaticle.typedb.common.test.core.TypeDBCoreRunner;
 import com.vaticle.typedb.common.test.TypeDBSingleton;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
@@ -65,6 +67,31 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
     @Override
     TypeDBOptions createOptions() {
         return TypeDBOptions.core();
+    }
+
+    @Override
+    @When("open connection")
+    public void open_connection() {
+        client = createTypeDBClient(TypeDBSingleton.getTypeDBRunner().address());
+    }
+
+    @When("typedb starts")
+    public void typedb_starts() {
+        TypeDBRunner runner = TypeDBSingleton.getTypeDBRunner();
+        if (runner != null && runner.isStopped()) {
+            runner.start();
+        } else {
+            try {
+                TypeDBCoreRunner typeDBCoreRunner = new TypeDBCoreRunner();
+                TypeDBSingleton.setTypeDBRunner(typeDBCoreRunner);
+                typeDBCoreRunner.start();
+            } catch (Exception e) {}
+        }
+    }
+
+    @When("typedb stops")
+    public void typedb_stops() {
+        TypeDBSingleton.getTypeDBRunner().stop();
     }
 
     @Given("connection has been opened")

--- a/test/behaviour/connection/ConnectionStepsCore.java
+++ b/test/behaviour/connection/ConnectionStepsCore.java
@@ -39,14 +39,8 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
     private TypeDBCoreRunner server;
 
     @Override
-    void beforeAll() {
-        try {
-            server = new TypeDBCoreRunner();
-        } catch (InterruptedException | TimeoutException | IOException e) {
-            throw new RuntimeException(e);
-        }
-        server.start();
-        TypeDBSingleton.setTypeDBRunner(server);
+    public void beforeAll() {
+        super.beforeAll();
     }
 
     @Before

--- a/test/behaviour/connection/user/BUILD
+++ b/test/behaviour/connection/user/BUILD
@@ -35,6 +35,7 @@ java_library(
         "//:client-java",
         "//api:api",
         "//test/behaviour/connection:steps-base",
+        "//test/behaviour/util:util",
 
         # Internal Repository Dependencies
         "@vaticle_typedb_common//test:typedb-runner",

--- a/test/behaviour/connection/user/BUILD
+++ b/test/behaviour/connection/user/BUILD
@@ -32,7 +32,6 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         # Internal Package Dependencies
-        "//:client-java",
         "//api:api",
         "//test/behaviour/connection:steps-base",
         "//test/behaviour/util:util",
@@ -63,6 +62,7 @@ typedb_java_test(
         "//test/behaviour/connection/session:steps",
         "//test/behaviour/connection/transaction:steps",
         "//test/behaviour/typeql:steps",
+        "//test/behaviour/util:steps",
 
         "//test/behaviour/config:parameters",
     ],

--- a/test/behaviour/connection/user/BUILD
+++ b/test/behaviour/connection/user/BUILD
@@ -36,11 +36,7 @@ java_library(
         "//api:api",
         "//test/behaviour/connection:steps-base",
         "//test/behaviour/util:util",
-        "//test/behaviour/util:steps",
 
-        # Internal Repository Dependencies
-        "@vaticle_typedb_common//test:typedb-runner",
-        
         # External Maven Dependencies
         "@maven//:junit_junit",
         "@maven//:io_cucumber_cucumber_java",

--- a/test/behaviour/connection/user/BUILD
+++ b/test/behaviour/connection/user/BUILD
@@ -36,6 +36,7 @@ java_library(
         "//api:api",
         "//test/behaviour/connection:steps-base",
         "//test/behaviour/util:util",
+        "//test/behaviour/util:steps",
 
         # Internal Repository Dependencies
         "@vaticle_typedb_common//test:typedb-runner",

--- a/test/behaviour/connection/user/UserSteps.java
+++ b/test/behaviour/connection/user/UserSteps.java
@@ -27,14 +27,15 @@ import com.vaticle.typedb.client.api.TypeDBCredential;
 import com.vaticle.typedb.client.api.database.Database;
 import com.vaticle.typedb.client.api.user.User;
 import com.vaticle.typedb.common.test.TypeDBSingleton;
-import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStepsBase.client;
+import static com.vaticle.typedb.client.test.behaviour.util.Util.assertThrows;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -46,39 +47,83 @@ public class UserSteps {
         return (TypeDBClient.Cluster) client;
     }
 
-    @Given("users contains: {word}")
-    public void users_contains(String username) {
+    public boolean user_is_in_users(String username) {
         Set<String> users = getClient().users().all().stream().map(User::username).collect(Collectors.toSet());
-        assertTrue(users.contains(username));
+        return users.contains(username);
+    }
+
+    @Then("users contains: {word}")
+    public void users_contains(String username) {
+        assertTrue(user_is_in_users(username));
     }
 
     @Then("users not contains: {word}")
     public void not_users_contains(String username) {
-        Set<String> users = getClient().users().all().stream().map(User::username).collect(Collectors.toSet());
-        assertFalse(users.contains(username));
+        assertFalse(user_is_in_users(username));
     }
 
-    @Then("users create: {word}, {word}")
+    @When("users create: {word}, {word}")
     public void users_create(String username, String password) {
         getClient().users().create(username, password);
     }
 
-    @Then("users delete: {word}")
+    @When("users delete: {word}")
     public void users_delete(String username) {
         getClient().users().delete(username);
     }
 
-    @Then("users password set: {word}, {word}")
+    @When("users password set: {word}, {word}")
     public void user_password_set(String username, String password) {
         getClient().users().passwordSet(username, password);
     }
 
-    @Then("user password update: {word}, {word}, {word}")
+    @When("disconnect current user")
+    public void disconnect_current_user() {
+        client.close();
+        client = null;
+    }
+
+    @When("user password update: {word}, {word}, {word}")
     public void user_password_update(String username, String passwordOld, String passwordNew) {
         getClient().users().get(username).passwordUpdate(passwordOld, passwordNew);
     }
 
-    @Then("user connect: {word}, {word}")
+    @When("user password set: {word}, {word}")
+    public void user_password_update(String username, String passwordNew) {
+        getClient().users().passwordSet(username, passwordNew);
+    }
+
+    @Then("users contains: {word}; throws exception")
+    public void users_contains_throws_exception(String username) {
+        assertThrows(() -> user_is_in_users(username));
+    }
+
+    @Then("users not contains: {word}; throws exception")
+    public void not_users_contains_throws_exception(String username) {
+        assertThrows(() -> user_is_in_users(username));
+    }
+
+    @When("users create: {word}, {word}; throws exception")
+    public void users_create_throws_exception(String username, String password) {
+        assertThrows(() -> getClient().users().create(username, password));
+    }
+
+    @When("users delete: {word}; throws exception")
+    public void users_delete_throws_exception(String username) {
+        assertThrows(() -> getClient().users().delete(username));
+    }
+
+    @When("users password set: {word}, {word}; throws exception")
+    public void user_password_set_throws_exception(String username, String password) {
+        assertThrows(() -> getClient().users().passwordSet(username, password));
+    }
+
+    @When("user password set: {word}, {word}; throws exception")
+    public void user_password_update_throws_exception(String username, String passwordNew) {
+        assertThrows(() -> getClient().users().passwordSet(username, passwordNew));
+    }
+
+    @When("user connect: {word}, {word}")
     public void user_connect(String username, String password) {
         String address = TypeDBSingleton.getTypeDBRunner().address();
         TypeDBCredential credential = new TypeDBCredential(username, password, false);

--- a/test/behaviour/connection/user/UserSteps.java
+++ b/test/behaviour/connection/user/UserSteps.java
@@ -79,10 +79,15 @@ public class UserSteps {
 
     @When("user password update: {word}, {word}")
     public void user_password_update(String passwordOld, String passwordNew) {
-        getClient().users().get(client.asCluster().user().username()).passwordUpdate(passwordOld, passwordNew);
+        getClient().users().get(getClient().user().username()).passwordUpdate(passwordOld, passwordNew);
     }
 
-    @When("user password set: {word}, {word}")
+    @Then("user expiry-days")
+    public void user_expiry_days() {
+        getClient().user().passwordExpiryDays();
+    }
+
+    @When("users password set: {word}, {word}")
     public void user_password_set(String username, String passwordNew) {
         getClient().users().passwordSet(username, passwordNew);
     }
@@ -100,7 +105,6 @@ public class UserSteps {
             Set<User> ignored = getClient().users().all();
         });
     }
-
 
     @Then("users contains: {word}; throws exception")
     public void users_contains_throws_exception(String username) {

--- a/test/behaviour/connection/user/UserSteps.java
+++ b/test/behaviour/connection/user/UserSteps.java
@@ -82,9 +82,9 @@ public class UserSteps {
         getClient().users().get(getClient().user().username()).passwordUpdate(passwordOld, passwordNew);
     }
 
-    @Then("user expiry-days")
-    public void user_expiry_days() {
-        getClient().user().passwordExpiryDays();
+    @Then("user expiry-seconds")
+    public void user_expiry_seconds() {
+        getClient().user().passwordExpirySeconds();
     }
 
     @When("users password set: {word}, {word}")

--- a/test/behaviour/connection/user/UserSteps.java
+++ b/test/behaviour/connection/user/UserSteps.java
@@ -21,16 +21,11 @@
 
 package com.vaticle.typedb.client.test.behaviour.connection.user;
 
-import com.vaticle.typedb.client.TypeDB;
 import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBCredential;
-import com.vaticle.typedb.client.api.database.Database;
 import com.vaticle.typedb.client.api.user.User;
-import com.vaticle.typedb.common.test.TypeDBSingleton;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -50,6 +45,16 @@ public class UserSteps {
     public boolean user_is_in_users(String username) {
         Set<String> users = getClient().users().all().stream().map(User::username).collect(Collectors.toSet());
         return users.contains(username);
+    }
+
+    @Then("users get user: {word}")
+    public void users_get(String username) {
+        User ignored = getClient().users().get(username);
+    }
+
+    @Then("users get all")
+    public void users_get_all() {
+        Set<User> ignored = getClient().users().all();
     }
 
     @Then("users contains: {word}")
@@ -72,26 +77,30 @@ public class UserSteps {
         getClient().users().delete(username);
     }
 
-    @When("users password set: {word}, {word}")
-    public void user_password_set(String username, String password) {
-        getClient().users().passwordSet(username, password);
-    }
-
-    @When("disconnect current user")
-    public void disconnect_current_user() {
-        client.close();
-        client = null;
-    }
-
-    @When("user password update: {word}, {word}, {word}")
-    public void user_password_update(String username, String passwordOld, String passwordNew) {
-        getClient().users().get(username).passwordUpdate(passwordOld, passwordNew);
+    @When("user password update: {word}, {word}")
+    public void user_password_update(String passwordOld, String passwordNew) {
+        getClient().users().get(client.asCluster().user().username()).passwordUpdate(passwordOld, passwordNew);
     }
 
     @When("user password set: {word}, {word}")
-    public void user_password_update(String username, String passwordNew) {
+    public void user_password_set(String username, String passwordNew) {
         getClient().users().passwordSet(username, passwordNew);
     }
+
+    @Then("users get user: {word}; throws exception")
+    public void users_get_throws_exception(String username) {
+        assertThrows(() -> {
+            User ignored = getClient().users().get(username);
+        });
+    }
+
+    @Then("users get all; throws exception")
+    public void users_get_all_throws_exception() {
+        assertThrows(() -> {
+            Set<User> ignored = getClient().users().all();
+        });
+    }
+
 
     @Then("users contains: {word}; throws exception")
     public void users_contains_throws_exception(String username) {
@@ -113,22 +122,13 @@ public class UserSteps {
         assertThrows(() -> getClient().users().delete(username));
     }
 
+    @When("user password update: {word}, {word}; throws exception")
+    public void user_password_update_throws_exception(String passwordOld, String passwordNew) {
+        assertThrows(() -> getClient().users().get(client.asCluster().user().username()).passwordUpdate(passwordOld, passwordNew));
+    }
+
     @When("users password set: {word}, {word}; throws exception")
-    public void user_password_set_throws_exception(String username, String password) {
-        assertThrows(() -> getClient().users().passwordSet(username, password));
-    }
-
-    @When("user password set: {word}, {word}; throws exception")
-    public void user_password_update_throws_exception(String username, String passwordNew) {
+    public void users_password_update_throws_exception(String username, String passwordNew) {
         assertThrows(() -> getClient().users().passwordSet(username, passwordNew));
-    }
-
-    @When("user connect: {word}, {word}")
-    public void user_connect(String username, String password) {
-        String address = TypeDBSingleton.getTypeDBRunner().address();
-        TypeDBCredential credential = new TypeDBCredential(username, password, false);
-        try (TypeDBClient.Cluster client = TypeDB.clusterClient(address, credential)) {
-            List<Database.Cluster> ignored = client.databases().all();
-        }
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We've added behaviour tests for password policy complexity and expiration to TypeDB Cluster.

Following new methodology which isolates the test runners made in typedb-common, we've increased the Bazel test timeout to 30 minutes. Previously this wasn't necessary as we would re-use the runners between runs following a 'cleaning' step, but not rebooting the runner. Given each boot of TypeDB takes 3-4 seconds, the 97 scenarios in the match behaviour file would take ~339.5 seconds in booting time alone, exhausting the default Bazel test limit of 300 seconds.

Now we take a more comprehensive approach, deleting all of the state stored in TypeDB between runs and allowing runners to be reset. This is more correct, but it takes more time.

## What are the changes implemented in this PR?

Many new steps have been declared in `UserSteps`:
* `users get user: {word}`
* `users get all`
* `users contains: {word}`
* `users not contains: {word}`
* `users create: {word}, {word}`
* `users delete: {word}`
* `user password update: {word}, {word}`
* `user expiry-seconds`
* `users password set: {word}, {word}`
* All of the above with the extension `; throws exception` 

We've also declared the following steps for `ConnectionStepsCluster`:
* `typedb has configuration` 
* `typedb starts`
* `typedb stops`
* `user connect: {word}, {word}`
* `user disconnect`