### PR TITLE
Introduce Values to support expressions

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -125,6 +125,7 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-core.sh //test/behaviour/typeql/language/match/... --test_output=errors
         .factory/test-core.sh //test/behaviour/typeql/language/get/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/typeql/language/expression/... --test_output=errors
     test-behaviour-match-cluster:
       image: vaticle-ubuntu-22.04
       dependencies:
@@ -136,6 +137,7 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-cluster.sh //test/behaviour/typeql/language/match/... --test_output=errors
         .factory/test-cluster.sh //test/behaviour/typeql/language/get/... --test_output=errors
+        .factory/test-core.sh //test/behaviour/typeql/language/expression/... --test_output=errors
     test-behaviour-writable-core:
       image: vaticle-ubuntu-22.04
       dependencies:

--- a/api/concept/Concept.java
+++ b/api/concept/Concept.java
@@ -23,6 +23,7 @@ package com.vaticle.typedb.client.api.concept;
 
 import com.eclipsesource.json.JsonObject;
 import com.vaticle.typedb.client.api.TypeDBTransaction;
+import com.vaticle.typedb.client.api.concept.value.Value;
 import com.vaticle.typedb.client.api.concept.thing.Attribute;
 import com.vaticle.typedb.client.api.concept.thing.Entity;
 import com.vaticle.typedb.client.api.concept.thing.Relation;
@@ -89,6 +90,11 @@ public interface Concept {
     }
 
     @CheckReturnValue
+    default boolean isValue() {
+        return false;
+    }
+
+    @CheckReturnValue
     Type asType();
 
     @CheckReturnValue
@@ -117,6 +123,9 @@ public interface Concept {
 
     @CheckReturnValue
     Relation asRelation();
+
+    @CheckReturnValue
+    Value<?> asValue();
 
     @CheckReturnValue
     Remote asRemote(TypeDBTransaction transaction);

--- a/api/concept/Concept.java
+++ b/api/concept/Concept.java
@@ -34,8 +34,13 @@ import com.vaticle.typedb.client.api.concept.type.RelationType;
 import com.vaticle.typedb.client.api.concept.type.RoleType;
 import com.vaticle.typedb.client.api.concept.type.ThingType;
 import com.vaticle.typedb.client.api.concept.type.Type;
+import com.vaticle.typedb.client.common.exception.TypeDBClientException;
+import com.vaticle.typedb.protocol.ConceptProto;
 
 import javax.annotation.CheckReturnValue;
+import java.time.LocalDateTime;
+
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
 
 public interface Concept {
 
@@ -182,5 +187,74 @@ public interface Concept {
         @Override
         @CheckReturnValue
         Attribute.Remote<?> asAttribute();
+    }
+
+    enum ValueType {
+
+        OBJECT(Object.class),
+        BOOLEAN(AttributeType.Boolean.class),
+        LONG(AttributeType.Long.class),
+        DOUBLE(AttributeType.Double.class),
+        STRING(AttributeType.String.class),
+        DATETIME(LocalDateTime.class);
+
+        private final Class<?> valueClass;
+
+        ValueType(Class<?> valueClass) {
+            this.valueClass = valueClass;
+        }
+
+        @CheckReturnValue
+        public static ValueType of(ConceptProto.ValueType valueType) {
+            switch (valueType) {
+                case BOOLEAN:
+                    return BOOLEAN;
+                case LONG:
+                    return LONG;
+                case DOUBLE:
+                    return DOUBLE;
+                case STRING:
+                    return STRING;
+                case DATETIME:
+                    return DATETIME;
+                default:
+                    throw new TypeDBClientException(BAD_VALUE_TYPE, valueType);
+            }
+        }
+
+        @CheckReturnValue
+        public static ValueType of(Class<?> valueClass) {
+            for (ValueType t : ValueType.values()) {
+                if (t.valueClass == valueClass) {
+                    return t;
+                }
+            }
+            throw new TypeDBClientException(BAD_VALUE_TYPE);
+        }
+
+        @CheckReturnValue
+        public Class<?> valueClass() {
+            return valueClass;
+        }
+
+        @CheckReturnValue
+        public ConceptProto.ValueType proto() {
+            switch (this) {
+                case OBJECT:
+                    return ConceptProto.ValueType.OBJECT;
+                case BOOLEAN:
+                    return ConceptProto.ValueType.BOOLEAN;
+                case LONG:
+                    return ConceptProto.ValueType.LONG;
+                case DOUBLE:
+                    return ConceptProto.ValueType.DOUBLE;
+                case STRING:
+                    return ConceptProto.ValueType.STRING;
+                case DATETIME:
+                    return ConceptProto.ValueType.DATETIME;
+                default:
+                    return ConceptProto.ValueType.UNRECOGNIZED;
+            }
+        }
     }
 }

--- a/api/concept/type/AttributeType.java
+++ b/api/concept/type/AttributeType.java
@@ -23,8 +23,6 @@ package com.vaticle.typedb.client.api.concept.type;
 
 import com.vaticle.typedb.client.api.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.thing.Attribute;
-import com.vaticle.typedb.client.common.exception.TypeDBClientException;
-import com.vaticle.typedb.protocol.ConceptProto;
 import com.vaticle.typeql.lang.common.TypeQLToken;
 
 import javax.annotation.CheckReturnValue;
@@ -32,8 +30,6 @@ import javax.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import static com.vaticle.typedb.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
 
 public interface AttributeType extends ThingType {
 
@@ -91,71 +87,6 @@ public interface AttributeType extends ThingType {
 
     @CheckReturnValue
     AttributeType.DateTime asDateTime();
-
-    enum ValueType {
-
-        OBJECT(Object.class, false, false),
-        BOOLEAN(Boolean.class, true, false),
-        LONG(Long.class, true, true),
-        DOUBLE(Double.class, true, false),
-        STRING(String.class, true, true),
-        DATETIME(LocalDateTime.class, true, true);
-
-        private final Class<?> valueClass;
-        private final boolean isWritable;
-        private final boolean isKeyable;
-
-        ValueType(Class<?> valueClass, boolean isWritable, boolean isKeyable) {
-            this.valueClass = valueClass;
-            this.isWritable = isWritable;
-            this.isKeyable = isKeyable;
-        }
-
-        @CheckReturnValue
-        public static ValueType of(Class<?> valueClass) {
-            for (ValueType t : ValueType.values()) {
-                if (t.valueClass == valueClass) {
-                    return t;
-                }
-            }
-            throw new TypeDBClientException(BAD_VALUE_TYPE);
-        }
-
-        @CheckReturnValue
-        public Class<?> valueClass() {
-            return valueClass;
-        }
-
-        @CheckReturnValue
-        public boolean isWritable() {
-            return isWritable;
-        }
-
-        @CheckReturnValue
-        public boolean isKeyable() {
-            return isKeyable;
-        }
-
-        @CheckReturnValue
-        public ConceptProto.AttributeType.ValueType proto() {
-            switch (this) {
-                case OBJECT:
-                    return ConceptProto.AttributeType.ValueType.OBJECT;
-                case BOOLEAN:
-                    return ConceptProto.AttributeType.ValueType.BOOLEAN;
-                case LONG:
-                    return ConceptProto.AttributeType.ValueType.LONG;
-                case DOUBLE:
-                    return ConceptProto.AttributeType.ValueType.DOUBLE;
-                case STRING:
-                    return ConceptProto.AttributeType.ValueType.STRING;
-                case DATETIME:
-                    return ConceptProto.AttributeType.ValueType.DATETIME;
-                default:
-                    return ConceptProto.AttributeType.ValueType.UNRECOGNIZED;
-            }
-        }
-    }
 
     interface Remote extends ThingType.Remote, AttributeType {
 

--- a/api/concept/type/ThingType.java
+++ b/api/concept/type/ThingType.java
@@ -23,7 +23,6 @@ package com.vaticle.typedb.client.api.concept.type;
 
 import com.vaticle.typedb.client.api.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.thing.Thing;
-import com.vaticle.typedb.client.api.concept.type.AttributeType.ValueType;
 import com.vaticle.typeql.lang.common.TypeQLToken;
 
 import javax.annotation.CheckReturnValue;

--- a/api/concept/type/Type.java
+++ b/api/concept/type/Type.java
@@ -57,7 +57,6 @@ public interface Type extends Concept {
 
     interface Remote extends Type, Concept.Remote {
 
-
         void setLabel(String label);
 
         @Nullable

--- a/api/concept/type/Type.java
+++ b/api/concept/type/Type.java
@@ -26,15 +26,10 @@ import com.eclipsesource.json.JsonObject;
 import com.vaticle.typedb.client.api.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.Concept;
 import com.vaticle.typedb.client.common.Label;
-import com.vaticle.typedb.client.common.exception.TypeDBClientException;
-import com.vaticle.typedb.protocol.ConceptProto;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
-import java.time.LocalDateTime;
 import java.util.stream.Stream;
-
-import static com.vaticle.typedb.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
 
 public interface Type extends Concept {
 
@@ -77,74 +72,5 @@ public interface Type extends Concept {
 
         @CheckReturnValue
         Stream<? extends Type> getSubtypesExplicit();
-    }
-
-    enum ValueType {
-
-        OBJECT(Object.class),
-        BOOLEAN(AttributeType.Boolean.class),
-        LONG(AttributeType.Long.class),
-        DOUBLE(AttributeType.Double.class),
-        STRING(AttributeType.String.class),
-        DATETIME(LocalDateTime.class);
-
-        private final Class<?> valueClass;
-
-        ValueType(Class<?> valueClass) {
-            this.valueClass = valueClass;
-        }
-
-        @CheckReturnValue
-        public static ValueType of(ConceptProto.ValueType valueType) {
-            switch (valueType) {
-                case BOOLEAN:
-                    return BOOLEAN;
-                case LONG:
-                    return LONG;
-                case DOUBLE:
-                    return DOUBLE;
-                case STRING:
-                    return STRING;
-                case DATETIME:
-                    return DATETIME;
-                default:
-                    throw new TypeDBClientException(BAD_VALUE_TYPE, valueType);
-            }
-        }
-
-        @CheckReturnValue
-        public static ValueType of(Class<?> valueClass) {
-            for (ValueType t : ValueType.values()) {
-                if (t.valueClass == valueClass) {
-                    return t;
-                }
-            }
-            throw new TypeDBClientException(BAD_VALUE_TYPE);
-        }
-
-        @CheckReturnValue
-        public Class<?> valueClass() {
-            return valueClass;
-        }
-
-        @CheckReturnValue
-        public ConceptProto.ValueType proto() {
-            switch (this) {
-                case OBJECT:
-                    return ConceptProto.ValueType.OBJECT;
-                case BOOLEAN:
-                    return ConceptProto.ValueType.BOOLEAN;
-                case LONG:
-                    return ConceptProto.ValueType.LONG;
-                case DOUBLE:
-                    return ConceptProto.ValueType.DOUBLE;
-                case STRING:
-                    return ConceptProto.ValueType.STRING;
-                case DATETIME:
-                    return ConceptProto.ValueType.DATETIME;
-                default:
-                    return ConceptProto.ValueType.UNRECOGNIZED;
-            }
-        }
     }
 }

--- a/api/concept/value/Value.java
+++ b/api/concept/value/Value.java
@@ -27,17 +27,10 @@ import com.eclipsesource.json.JsonValue;
 import com.vaticle.typedb.client.api.concept.Concept;
 import com.vaticle.typedb.client.api.concept.type.Type;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
-import com.vaticle.typedb.protocol.ConceptProto;
 
 import javax.annotation.CheckReturnValue;
 
 import static com.vaticle.typedb.client.api.concept.thing.Attribute.ISO_LOCAL_DATE_TIME_MILLIS;
-import static com.vaticle.typedb.client.api.concept.type.Type.ValueType.BOOLEAN;
-import static com.vaticle.typedb.client.api.concept.type.Type.ValueType.DATETIME;
-import static com.vaticle.typedb.client.api.concept.type.Type.ValueType.DOUBLE;
-import static com.vaticle.typedb.client.api.concept.type.Type.ValueType.LONG;
-import static com.vaticle.typedb.client.api.concept.type.Type.ValueType.STRING;
-import static com.vaticle.typedb.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 
 public interface Value<VALUE> extends Concept {

--- a/api/concept/value/Value.java
+++ b/api/concept/value/Value.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.vaticle.typedb.client.api.concept.value;
+
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
+import com.vaticle.typedb.client.api.concept.Concept;
+import com.vaticle.typedb.client.api.concept.type.Type;
+import com.vaticle.typedb.client.common.exception.TypeDBClientException;
+import com.vaticle.typedb.protocol.ConceptProto;
+
+import javax.annotation.CheckReturnValue;
+
+import static com.vaticle.typedb.client.api.concept.thing.Attribute.ISO_LOCAL_DATE_TIME_MILLIS;
+import static com.vaticle.typedb.client.api.concept.type.Type.ValueType.BOOLEAN;
+import static com.vaticle.typedb.client.api.concept.type.Type.ValueType.DATETIME;
+import static com.vaticle.typedb.client.api.concept.type.Type.ValueType.DOUBLE;
+import static com.vaticle.typedb.client.api.concept.type.Type.ValueType.LONG;
+import static com.vaticle.typedb.client.api.concept.type.Type.ValueType.STRING;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+
+public interface Value<VALUE> extends Concept {
+
+    @CheckReturnValue
+    Type.ValueType getValueType();
+
+    @CheckReturnValue
+    VALUE getValue();
+
+    @Override
+    @CheckReturnValue
+    default boolean isValue() {
+        return true;
+    }
+
+    @CheckReturnValue
+    default boolean isBoolean() {
+        return false;
+    }
+
+    @CheckReturnValue
+    default boolean isLong() {
+        return false;
+    }
+
+    @CheckReturnValue
+    default boolean isDouble() {
+        return false;
+    }
+
+    @CheckReturnValue
+    default boolean isString() {
+        return false;
+    }
+
+    @CheckReturnValue
+    default boolean isDateTime() {
+        return false;
+    }
+
+    @CheckReturnValue
+    Value<java.lang.Boolean> asBoolean();
+
+    @CheckReturnValue
+    Value<java.lang.Long> asLong();
+
+    @CheckReturnValue
+    Value<java.lang.Double> asDouble();
+
+    @CheckReturnValue
+    Value<java.lang.String> asString();
+
+    @CheckReturnValue
+    Value<java.time.LocalDateTime> asDateTime();
+
+    @Override
+    default JsonObject toJSON() {
+        JsonValue value;
+        switch (getValueType()) {
+            case BOOLEAN:
+                value = Json.value(asBoolean().getValue());
+                break;
+            case LONG:
+                value = Json.value(asLong().getValue());
+                break;
+            case DOUBLE:
+                value = Json.value(asDouble().getValue());
+                break;
+            case STRING:
+                value = Json.value(asString().getValue());
+                break;
+            case DATETIME:
+                value = Json.value(asDateTime().getValue().format(ISO_LOCAL_DATE_TIME_MILLIS));
+                break;
+            default:
+                throw new TypeDBClientException(ILLEGAL_STATE);
+        }
+        return Json.object()
+                .add("value_type", getValueType().name().toLowerCase())
+                .add("value", value);
+    }
+
+    interface Boolean extends Value<java.lang.Boolean> {
+        @Override
+        @CheckReturnValue
+        default boolean isBoolean() {
+            return true;
+        }
+    }
+
+    interface Long extends Value<java.lang.Long> {
+        @Override
+        @CheckReturnValue
+        default boolean isLong() {
+            return true;
+        }
+    }
+
+    interface Double extends Value<java.lang.Double> {
+        @Override
+        @CheckReturnValue
+        default boolean isDouble() {
+            return true;
+        }
+    }
+
+    interface String extends Value<java.lang.String> {
+        @Override
+        @CheckReturnValue
+        default boolean isString() {
+            return true;
+        }
+    }
+
+    interface DateTime extends Value<java.time.LocalDateTime> {
+        @Override
+        @CheckReturnValue
+        default boolean isDateTime() {
+            return true;
+        }
+    }
+}

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -92,6 +92,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Concept(9, "The ownership by owner '%s' of attribute '%s' is not explainable.");
         public static final Concept UNRECOGNISED_ANNOTATION =
                 new Concept(10, "The annotation '%s' is not recognised");
+        public static final Concept VALUE_HAS_NO_REMOTE =
+                new Concept(11, "A 'value' has no remote concept.");
 
         private static final String codePrefix = "CON";
         private static final String messagePrefix = "Concept Error";

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -367,6 +367,30 @@ public class RequestBuilder {
         }
     }
 
+    public static class Concept {
+
+        public static ConceptProto.ConceptValue protoBooleanConceptValue(boolean value) {
+            return ConceptProto.ConceptValue.newBuilder().setBoolean(value).build();
+        }
+
+        public static ConceptProto.ConceptValue protoLongConceptValue(long value) {
+            return ConceptProto.ConceptValue.newBuilder().setLong(value).build();
+        }
+
+        public static ConceptProto.ConceptValue protoDoubleConceptValue(double value) {
+            return ConceptProto.ConceptValue.newBuilder().setDouble(value).build();
+        }
+
+        public static ConceptProto.ConceptValue protoStringConceptValue(String value) {
+            return ConceptProto.ConceptValue.newBuilder().setString(value).build();
+        }
+
+        public static ConceptProto.ConceptValue protoDateTimeConceptValue(LocalDateTime value) {
+            long epochMillis = value.atZone(ZoneOffset.UTC).toInstant().toEpochMilli();
+            return ConceptProto.ConceptValue.newBuilder().setDateTime(epochMillis).build();
+        }
+    }
+
     public static class Type {
 
         private static TransactionProto.Transaction.Req.Builder typeReq(ConceptProto.Type.Req.Builder req) {
@@ -818,27 +842,6 @@ public class RequestBuilder {
                 return thingReq(ConceptProto.Thing.Req.newBuilder().setIid(byteString(iid)).setAttributeGetOwnersReq(
                         ConceptProto.Attribute.GetOwners.Req.newBuilder().setThingType(ownerType)
                 ));
-            }
-
-            public static ConceptProto.ConceptValue protoBooleanAttributeValue(boolean value) {
-                return ConceptProto.ConceptValue.newBuilder().setBoolean(value).build();
-            }
-
-            public static ConceptProto.ConceptValue protoLongAttributeValue(long value) {
-                return ConceptProto.ConceptValue.newBuilder().setLong(value).build();
-            }
-
-            public static ConceptProto.ConceptValue protoDoubleAttributeValue(double value) {
-                return ConceptProto.ConceptValue.newBuilder().setDouble(value).build();
-            }
-
-            public static ConceptProto.ConceptValue protoStringAttributeValue(String value) {
-                return ConceptProto.ConceptValue.newBuilder().setString(value).build();
-            }
-
-            public static ConceptProto.ConceptValue protoDateTimeAttributeValue(LocalDateTime value) {
-                long epochMillis = value.atZone(ZoneOffset.UTC).toInstant().toEpochMilli();
-                return ConceptProto.ConceptValue.newBuilder().setDateTime(epochMillis).build();
             }
         }
     }

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -314,7 +314,7 @@ public class RequestBuilder {
         }
 
         public static TransactionProto.Transaction.Req.Builder putAttributeTypeReq(
-                String label, ConceptProto.AttributeType.ValueType valueType) {
+                String label, ConceptProto.ValueType valueType) {
             return conceptManagerReq(ConceptProto.ConceptManager.Req.newBuilder().setPutAttributeTypeReq(
                     ConceptProto.ConceptManager.PutAttributeType.Req.newBuilder().setLabel(label).setValueType(valueType)
             ));
@@ -536,7 +536,7 @@ public class RequestBuilder {
             }
 
             public static TransactionProto.Transaction.Req.Builder getOwnsReq(
-                    Label label, ConceptProto.AttributeType.ValueType valueType, Set<ConceptProto.Type.Annotation> annotations) {
+                    Label label, ConceptProto.ValueType valueType, Set<ConceptProto.Type.Annotation> annotations) {
                 return typeReq(newReqBuilder(label).setThingTypeGetOwnsReq(
                         ConceptProto.ThingType.GetOwns.Req.newBuilder().addAllAnnotations(annotations)
                                 .setValueType(valueType)
@@ -550,7 +550,7 @@ public class RequestBuilder {
             }
 
             public static TransactionProto.Transaction.Req.Builder getOwnsExplicitReq(
-                    Label label, ConceptProto.AttributeType.ValueType valueType, Set<ConceptProto.Type.Annotation> annotations) {
+                    Label label, ConceptProto.ValueType valueType, Set<ConceptProto.Type.Annotation> annotations) {
                 return typeReq(newReqBuilder(label).setThingTypeGetOwnsExplicitReq(
                         ConceptProto.ThingType.GetOwnsExplicit.Req.newBuilder().addAllAnnotations(annotations)
                                 .setValueType(valueType)
@@ -686,13 +686,13 @@ public class RequestBuilder {
                 ));
             }
 
-            public static TransactionProto.Transaction.Req.Builder putReq(Label label, ConceptProto.Attribute.Value value) {
+            public static TransactionProto.Transaction.Req.Builder putReq(Label label, ConceptProto.ConceptValue value) {
                 return typeReq(newReqBuilder(label).setAttributeTypePutReq(
                         ConceptProto.AttributeType.Put.Req.newBuilder().setValue(value)
                 ));
             }
 
-            public static TransactionProto.Transaction.Req.Builder getReq(Label label, ConceptProto.Attribute.Value value) {
+            public static TransactionProto.Transaction.Req.Builder getReq(Label label, ConceptProto.ConceptValue value) {
                 return typeReq(newReqBuilder(label).setAttributeTypeGetReq(
                         ConceptProto.AttributeType.Get.Req.newBuilder().setValue(value)
                 ));
@@ -820,25 +820,25 @@ public class RequestBuilder {
                 ));
             }
 
-            public static ConceptProto.Attribute.Value protoBooleanAttributeValue(boolean value) {
-                return ConceptProto.Attribute.Value.newBuilder().setBoolean(value).build();
+            public static ConceptProto.ConceptValue protoBooleanAttributeValue(boolean value) {
+                return ConceptProto.ConceptValue.newBuilder().setBoolean(value).build();
             }
 
-            public static ConceptProto.Attribute.Value protoLongAttributeValue(long value) {
-                return ConceptProto.Attribute.Value.newBuilder().setLong(value).build();
+            public static ConceptProto.ConceptValue protoLongAttributeValue(long value) {
+                return ConceptProto.ConceptValue.newBuilder().setLong(value).build();
             }
 
-            public static ConceptProto.Attribute.Value protoDoubleAttributeValue(double value) {
-                return ConceptProto.Attribute.Value.newBuilder().setDouble(value).build();
+            public static ConceptProto.ConceptValue protoDoubleAttributeValue(double value) {
+                return ConceptProto.ConceptValue.newBuilder().setDouble(value).build();
             }
 
-            public static ConceptProto.Attribute.Value protoStringAttributeValue(String value) {
-                return ConceptProto.Attribute.Value.newBuilder().setString(value).build();
+            public static ConceptProto.ConceptValue protoStringAttributeValue(String value) {
+                return ConceptProto.ConceptValue.newBuilder().setString(value).build();
             }
 
-            public static ConceptProto.Attribute.Value protoDateTimeAttributeValue(LocalDateTime value) {
+            public static ConceptProto.ConceptValue protoDateTimeAttributeValue(LocalDateTime value) {
                 long epochMillis = value.atZone(ZoneOffset.UTC).toInstant().toEpochMilli();
-                return ConceptProto.Attribute.Value.newBuilder().setDateTime(epochMillis).build();
+                return ConceptProto.ConceptValue.newBuilder().setDateTime(epochMillis).build();
             }
         }
     }

--- a/concept/ConceptImpl.java
+++ b/concept/ConceptImpl.java
@@ -22,6 +22,7 @@
 package com.vaticle.typedb.client.concept;
 
 import com.vaticle.typedb.client.api.concept.Concept;
+import com.vaticle.typedb.client.api.concept.value.Value;
 import com.vaticle.typedb.client.api.concept.thing.Attribute;
 import com.vaticle.typedb.client.api.concept.thing.Entity;
 import com.vaticle.typedb.client.api.concept.thing.Relation;
@@ -33,6 +34,7 @@ import com.vaticle.typedb.client.api.concept.type.RoleType;
 import com.vaticle.typedb.client.api.concept.type.ThingType;
 import com.vaticle.typedb.client.api.concept.type.Type;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
+import com.vaticle.typedb.client.concept.value.ValueImpl;
 import com.vaticle.typedb.client.concept.thing.AttributeImpl;
 import com.vaticle.typedb.client.concept.thing.EntityImpl;
 import com.vaticle.typedb.client.concept.thing.RelationImpl;
@@ -46,13 +48,16 @@ import com.vaticle.typedb.client.concept.type.TypeImpl;
 import com.vaticle.typedb.protocol.ConceptProto;
 
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.common.util.Objects.className;
 
 public abstract class ConceptImpl implements Concept {
 
     public static Concept of(ConceptProto.Concept protoConcept) {
         if (protoConcept.hasThing()) return ThingImpl.of(protoConcept.getThing());
-        else return TypeImpl.of(protoConcept.getType());
+        else if (protoConcept.hasType()) return TypeImpl.of(protoConcept.getType());
+        else if (protoConcept.hasValue()) return ValueImpl.of(protoConcept.getValue());
+        else throw new TypeDBClientException(ILLEGAL_STATE);
     }
 
     @Override
@@ -110,6 +115,11 @@ public abstract class ConceptImpl implements Concept {
         throw new TypeDBClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Relation.class));
     }
 
+    @Override
+    public ValueImpl<?> asValue() {
+        throw new TypeDBClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Value.class));
+    }
+
     public abstract static class Remote implements Concept.Remote {
 
         @Override
@@ -165,6 +175,11 @@ public abstract class ConceptImpl implements Concept {
         @Override
         public AttributeImpl.Remote<?> asAttribute() {
             throw new TypeDBClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Attribute.class));
+        }
+
+        @Override
+        public ValueImpl<?> asValue() {
+            throw new TypeDBClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Value.class));
         }
     }
 }

--- a/concept/thing/AttributeImpl.java
+++ b/concept/thing/AttributeImpl.java
@@ -459,11 +459,12 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         }
 
         public static AttributeImpl.DateTime of(ConceptProto.Thing thingProto) {
+            long rpcDatetime = thingProto.getValue().getDateTime();
             return new AttributeImpl.DateTime(
                     bytesToHexString(thingProto.getIid().toByteArray()),
                     thingProto.getInferred(),
                     AttributeTypeImpl.DateTime.of(thingProto.getType()),
-                    toLocalDateTime(thingProto.getValue().getDateTime())
+                    LocalDateTime.ofInstant(Instant.ofEpochMilli(rpcDatetime), ZoneOffset.UTC)
             );
         }
 
@@ -485,10 +486,6 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
         @Override
         public AttributeImpl.DateTime.Remote asRemote(TypeDBTransaction transaction) {
             return new AttributeImpl.DateTime.Remote(transaction, getIID(), isInferred(), type, value);
-        }
-
-        private static LocalDateTime toLocalDateTime(long rpcDatetime) {
-            return LocalDateTime.ofInstant(Instant.ofEpochMilli(rpcDatetime), ZoneOffset.UTC);
         }
 
         public static class Remote extends AttributeImpl.Remote<LocalDateTime> implements Attribute.DateTime.Remote {

--- a/concept/type/AttributeTypeImpl.java
+++ b/concept/type/AttributeTypeImpl.java
@@ -207,13 +207,13 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
                     .map(ThingTypeImpl::of);
         }
 
-        protected final AttributeImpl<?> put(ConceptProto.Attribute.Value protoValue) {
+        protected final AttributeImpl<?> put(ConceptProto.ConceptValue protoValue) {
             ConceptProto.Type.Res res = execute(putReq(getLabel(), protoValue));
             return AttributeImpl.of(res.getAttributeTypePutRes().getAttribute());
         }
 
         @Nullable
-        protected final AttributeImpl<?> get(ConceptProto.Attribute.Value value) {
+        protected final AttributeImpl<?> get(ConceptProto.ConceptValue value) {
             ConceptProto.Type.Res res = execute(getReq(getLabel(), value));
             switch (res.getAttributeTypeGetRes().getResCase()) {
                 case ATTRIBUTE:

--- a/concept/type/AttributeTypeImpl.java
+++ b/concept/type/AttributeTypeImpl.java
@@ -37,11 +37,11 @@ import java.util.stream.Stream;
 
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
-import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Thing.Attribute.protoBooleanAttributeValue;
-import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Thing.Attribute.protoDateTimeAttributeValue;
-import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Thing.Attribute.protoDoubleAttributeValue;
-import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Thing.Attribute.protoLongAttributeValue;
-import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Thing.Attribute.protoStringAttributeValue;
+import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Concept.protoBooleanConceptValue;
+import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Concept.protoDateTimeConceptValue;
+import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Concept.protoDoubleConceptValue;
+import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Concept.protoLongConceptValue;
+import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Concept.protoStringConceptValue;
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Type.AttributeType.getOwnersExplicitReq;
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Type.AttributeType.getOwnersReq;
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Type.AttributeType.getRegexReq;
@@ -331,13 +331,13 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             @Override
             public final AttributeImpl.Boolean put(boolean value) {
-                return super.put(protoBooleanAttributeValue(value)).asBoolean();
+                return super.put(protoBooleanConceptValue(value)).asBoolean();
             }
 
             @Nullable
             @Override
             public final AttributeImpl.Boolean get(boolean value) {
-                AttributeImpl<?> attr = super.get(protoBooleanAttributeValue(value));
+                AttributeImpl<?> attr = super.get(protoBooleanConceptValue(value));
                 return attr != null ? attr.asBoolean() : null;
             }
 
@@ -406,13 +406,13 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             @Override
             public final AttributeImpl.Long put(long value) {
-                return super.put(protoLongAttributeValue(value)).asLong();
+                return super.put(protoLongConceptValue(value)).asLong();
             }
 
             @Nullable
             @Override
             public final AttributeImpl.Long get(long value) {
-                AttributeImpl<?> attr = super.get(protoLongAttributeValue(value));
+                AttributeImpl<?> attr = super.get(protoLongConceptValue(value));
                 return attr != null ? attr.asLong() : null;
             }
 
@@ -481,13 +481,13 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             @Override
             public final AttributeImpl.Double put(double value) {
-                return super.put(protoDoubleAttributeValue(value)).asDouble();
+                return super.put(protoDoubleConceptValue(value)).asDouble();
             }
 
             @Nullable
             @Override
             public final AttributeImpl.Double get(double value) {
-                AttributeImpl<?> attr = super.get(protoDoubleAttributeValue(value));
+                AttributeImpl<?> attr = super.get(protoDoubleConceptValue(value));
                 return attr != null ? attr.asDouble() : null;
             }
 
@@ -556,13 +556,13 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             @Override
             public final AttributeImpl.String put(java.lang.String value) {
-                return super.put(protoStringAttributeValue(value)).asString();
+                return super.put(protoStringConceptValue(value)).asString();
             }
 
             @Nullable
             @Override
             public final AttributeImpl.String get(java.lang.String value) {
-                AttributeImpl<?> attr = super.get(protoStringAttributeValue(value));
+                AttributeImpl<?> attr = super.get(protoStringConceptValue(value));
                 return attr != null ? attr.asString() : null;
             }
 
@@ -645,13 +645,13 @@ public class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
             @Override
             public final AttributeImpl.DateTime put(LocalDateTime value) {
-                return super.put(protoDateTimeAttributeValue(value)).asDateTime();
+                return super.put(protoDateTimeConceptValue(value)).asDateTime();
             }
 
             @Nullable
             @Override
             public final AttributeImpl.DateTime get(LocalDateTime value) {
-                AttributeImpl<?> attr = super.get(protoDateTimeAttributeValue(value));
+                AttributeImpl<?> attr = super.get(protoDateTimeConceptValue(value));
                 return attr != null ? attr.asDateTime() : null;
             }
 

--- a/concept/type/ThingTypeImpl.java
+++ b/concept/type/ThingTypeImpl.java
@@ -23,7 +23,6 @@ package com.vaticle.typedb.client.concept.type;
 
 import com.vaticle.typedb.client.api.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.type.AttributeType;
-import com.vaticle.typedb.client.api.concept.type.AttributeType.ValueType;
 import com.vaticle.typedb.client.api.concept.type.RoleType;
 import com.vaticle.typedb.client.api.concept.type.ThingType;
 import com.vaticle.typedb.client.common.Label;

--- a/concept/value/ValueImpl.java
+++ b/concept/value/ValueImpl.java
@@ -23,7 +23,6 @@ package com.vaticle.typedb.client.concept.value;
 
 import com.vaticle.typedb.client.api.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.Concept;
-import com.vaticle.typedb.client.api.concept.type.Type.ValueType;
 import com.vaticle.typedb.client.api.concept.value.Value;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typedb.client.concept.ConceptImpl;

--- a/concept/value/ValueImpl.java
+++ b/concept/value/ValueImpl.java
@@ -23,7 +23,6 @@ package com.vaticle.typedb.client.concept.value;
 
 import com.vaticle.typedb.client.api.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.Concept;
-import com.vaticle.typedb.client.api.concept.type.Type;
 import com.vaticle.typedb.client.api.concept.type.Type.ValueType;
 import com.vaticle.typedb.client.api.concept.value.Value;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
@@ -118,7 +117,6 @@ public abstract class ValueImpl<VALUE> extends ConceptImpl implements Value<VALU
         }
 
         public static ValueImpl.Boolean of(ConceptProto.Value valueProto) {
-            assert valueProto.getValueType() == ConceptProto.ValueType.BOOLEAN;
             return new ValueImpl.Boolean(ValueType.of(valueProto.getValueType()), valueProto.getValue().getBoolean());
         }
 
@@ -133,7 +131,6 @@ public abstract class ValueImpl<VALUE> extends ConceptImpl implements Value<VALU
         }
 
         public static ValueImpl.Long of(ConceptProto.Value valueProto) {
-            assert valueProto.getValueType() == ConceptProto.ValueType.LONG;
             return new ValueImpl.Long(ValueType.of(valueProto.getValueType()), valueProto.getValue().getLong());
         }
 
@@ -142,13 +139,12 @@ public abstract class ValueImpl<VALUE> extends ConceptImpl implements Value<VALU
         }
     }
 
-    public static class Double extends ValueImpl<java.lang.Double>  implements Value.Double {
+    public static class Double extends ValueImpl<java.lang.Double> implements Value.Double {
         public Double(ValueType valueType, java.lang.Double value) {
             super(valueType, value);
         }
 
         public static ValueImpl.Double of(ConceptProto.Value valueProto) {
-            assert valueProto.getValueType() == ConceptProto.ValueType.DOUBLE;
             return new ValueImpl.Double(ValueType.of(valueProto.getValueType()), valueProto.getValue().getDouble());
         }
 
@@ -163,7 +159,6 @@ public abstract class ValueImpl<VALUE> extends ConceptImpl implements Value<VALU
         }
 
         public static ValueImpl.String of(ConceptProto.Value valueProto) {
-            assert valueProto.getValueType() == ConceptProto.ValueType.STRING;
             return new ValueImpl.String(ValueType.of(valueProto.getValueType()), valueProto.getValue().getString());
         }
 
@@ -178,9 +173,10 @@ public abstract class ValueImpl<VALUE> extends ConceptImpl implements Value<VALU
         }
 
         public static ValueImpl.DateTime of(ConceptProto.Value valueProto) {
-            assert valueProto.getValueType() == ConceptProto.ValueType.DATETIME;
-            return new ValueImpl.DateTime(ValueType.of(valueProto.getValueType()),
-                    LocalDateTime.ofInstant(Instant.ofEpochMilli(valueProto.getValue().getDateTime()), ZoneOffset.UTC));
+            return new ValueImpl.DateTime(
+                    ValueType.of(valueProto.getValueType()),
+                    LocalDateTime.ofInstant(Instant.ofEpochMilli(valueProto.getValue().getDateTime()), ZoneOffset.UTC)
+            );
         }
 
         public ValueImpl.DateTime asDateTime() {

--- a/concept/value/ValueImpl.java
+++ b/concept/value/ValueImpl.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.vaticle.typedb.client.concept.value;
+
+import com.vaticle.typedb.client.api.TypeDBTransaction;
+import com.vaticle.typedb.client.api.concept.Concept;
+import com.vaticle.typedb.client.api.concept.type.Type;
+import com.vaticle.typedb.client.api.concept.type.Type.ValueType;
+import com.vaticle.typedb.client.api.concept.value.Value;
+import com.vaticle.typedb.client.common.exception.TypeDBClientException;
+import com.vaticle.typedb.client.concept.ConceptImpl;
+import com.vaticle.typedb.protocol.ConceptProto;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Concept.BAD_VALUE_TYPE;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Concept.VALUE_HAS_NO_REMOTE;
+import static com.vaticle.typedb.common.util.Objects.className;
+
+public abstract class ValueImpl<VALUE> extends ConceptImpl implements Value<VALUE> {
+
+    protected final VALUE value;
+    private final ValueType valueType;
+
+    public ValueImpl(ValueType valueType, VALUE value) {
+        this.valueType = valueType;
+        this.value = value;
+    }
+
+    public static ValueImpl<?> of(ConceptProto.Value valueProto) {
+        switch (valueProto.getValueType()) {
+            case BOOLEAN:
+                return ValueImpl.Boolean.of(valueProto);
+            case LONG:
+                return ValueImpl.Long.of(valueProto);
+            case DOUBLE:
+                return ValueImpl.Double.of(valueProto);
+            case STRING:
+                return ValueImpl.String.of(valueProto);
+            case DATETIME:
+                return ValueImpl.DateTime.of(valueProto);
+            case UNRECOGNIZED:
+            default:
+                throw new TypeDBClientException(BAD_VALUE_TYPE, valueProto.getValueType());
+        }
+    }
+
+    @Override
+    public ValueImpl<?> asValue() {
+        return this;
+    }
+
+    @Override
+    public Concept.Remote asRemote(TypeDBTransaction transaction) {
+        throw new TypeDBClientException(VALUE_HAS_NO_REMOTE);
+    }
+
+    @Override
+    public ValueType getValueType() {
+        return valueType;
+    }
+
+    @Override
+    public VALUE getValue() {
+        return this.value;
+    }
+
+    @Override
+    public Value<java.lang.Boolean> asBoolean() {
+        throw new TypeDBClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Value.Boolean.class));
+    }
+
+    @Override
+    public Value<java.lang.Long> asLong() {
+        throw new TypeDBClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Value.Long.class));
+    }
+
+    @Override
+    public Value<java.lang.Double> asDouble() {
+        throw new TypeDBClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Value.Double.class));
+    }
+
+    @Override
+    public Value<java.lang.String> asString() {
+        throw new TypeDBClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Value.String.class));
+    }
+
+    @Override
+    public Value<LocalDateTime> asDateTime() {
+        throw new TypeDBClientException(INVALID_CONCEPT_CASTING, className(this.getClass()), className(Value.DateTime.class));
+    }
+
+    public static class Boolean extends ValueImpl<java.lang.Boolean> implements Value.Boolean {
+        public Boolean(ValueType valueType, java.lang.Boolean value) {
+            super(valueType, value);
+        }
+
+        public static ValueImpl.Boolean of(ConceptProto.Value valueProto) {
+            assert valueProto.getValueType() == ConceptProto.ValueType.BOOLEAN;
+            return new ValueImpl.Boolean(ValueType.of(valueProto.getValueType()), valueProto.getValue().getBoolean());
+        }
+
+        public ValueImpl.Boolean asBoolean() {
+            return this;
+        }
+    }
+
+    public static class Long extends ValueImpl<java.lang.Long> implements Value.Long {
+        public Long(ValueType valueType, java.lang.Long value) {
+            super(valueType, value);
+        }
+
+        public static ValueImpl.Long of(ConceptProto.Value valueProto) {
+            assert valueProto.getValueType() == ConceptProto.ValueType.LONG;
+            return new ValueImpl.Long(ValueType.of(valueProto.getValueType()), valueProto.getValue().getLong());
+        }
+
+        public ValueImpl.Long asLong() {
+            return this;
+        }
+    }
+
+    public static class Double extends ValueImpl<java.lang.Double>  implements Value.Double {
+        public Double(ValueType valueType, java.lang.Double value) {
+            super(valueType, value);
+        }
+
+        public static ValueImpl.Double of(ConceptProto.Value valueProto) {
+            assert valueProto.getValueType() == ConceptProto.ValueType.DOUBLE;
+            return new ValueImpl.Double(ValueType.of(valueProto.getValueType()), valueProto.getValue().getDouble());
+        }
+
+        public ValueImpl.Double asDouble() {
+            return this;
+        }
+    }
+
+    public static class String extends ValueImpl<java.lang.String> implements Value.String {
+        public String(ValueType valueType, java.lang.String value) {
+            super(valueType, value);
+        }
+
+        public static ValueImpl.String of(ConceptProto.Value valueProto) {
+            assert valueProto.getValueType() == ConceptProto.ValueType.STRING;
+            return new ValueImpl.String(ValueType.of(valueProto.getValueType()), valueProto.getValue().getString());
+        }
+
+        public ValueImpl.String asString() {
+            return this;
+        }
+    }
+
+    public static class DateTime extends ValueImpl<LocalDateTime> implements Value.DateTime {
+        public DateTime(ValueType valueType, LocalDateTime value) {
+            super(valueType, value);
+        }
+
+        public static ValueImpl.DateTime of(ConceptProto.Value valueProto) {
+            assert valueProto.getValueType() == ConceptProto.ValueType.DATETIME;
+            return new ValueImpl.DateTime(ValueType.of(valueProto.getValueType()),
+                    LocalDateTime.ofInstant(Instant.ofEpochMilli(valueProto.getValue().getDateTime()), ZoneOffset.UTC));
+        }
+
+        public ValueImpl.DateTime asDateTime() {
+            return this;
+        }
+    }
+}

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "291bda5992736b2272f36bfd2d893d37b3f13095"
+        commit = "816ef97845a9577c2236db69dd94548b5869c083"
     )
 
 def vaticle_typedb_cluster_artifact():
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifact():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "9b70d31b54ed0162ce5df6ac4ab6180229bd7cb9",
+        commit = "8044753056dd20b8e6bec6f62036eb0003d4ba06",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "55db856cedd83bb213bb7298c40ba6a72f67e8a8",
+        commit = "816ef97845a9577c2236db69dd94548b5869c083"
     )
 
 def vaticle_typedb_cluster_artifact():

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "816ef97845a9577c2236db69dd94548b5869c083"
+        commit = "291bda5992736b2272f36bfd2d893d37b3f13095"
     )
 
 def vaticle_typedb_cluster_artifact():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -39,14 +39,14 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/krishnangovindraj/typeql",
-        commit = "ff758c550b8e006c0b0420ea1b75cba613437af0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "169119466fb2c60e23339c99477c3fc2f8826aa0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/krishnangovindraj/typedb-protocol",
-        commit = "5c073e625770e812e4807419392d7f7261a553fb", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "486e9f095cba86abb829b2632c8502822bd7530b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -46,7 +46,7 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/krishnangovindraj/typedb-protocol",
-        commit = "486e9f095cba86abb829b2632c8502822bd7530b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "5c073e625770e812e4807419392d7f7261a553fb", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,35 +25,35 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "b968cab9c4d2f85d80a0069b8d15cce5afdd0da5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "385716283e1e64245c3679a06054e271a0608ac1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "9372dfb227d54c6eb631eed02e67f250e55e657e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "9372dfb227d54c6eb631eed02e67f250e55e657e" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/vaticle/typeql",
-        commit = "1a4c52089dd616f52ec52645e9754a8666a1b693", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/krishnangovindraj/typeql",
+        commit = "ff758c550b8e006c0b0420ea1b75cba613437af0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/vaticle/typedb-protocol",
-        commit = "de4f5b4d31c3ff06d62da47d2a57605c4e3d4b29", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/krishnangovindraj/typedb-protocol",
+        commit = "486e9f095cba86abb829b2632c8502822bd7530b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "aa675d9052046b1a4ffd45f444854d8735028702" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "ee75ae1ba31dfcf124f1b2f674401df5632224de" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -53,7 +53,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "19bf32fc8353f876b1a97d6467e26fbc55f99fab" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "709d5739148e301ef59db93ac0cfa0b24c6cbe1d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -53,7 +53,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "ee75ae1ba31dfcf124f1b2f674401df5632224de" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "19bf32fc8353f876b1a97d6467e26fbc55f99fab" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -38,22 +38,22 @@ def vaticle_typedb_common():
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/krishnangovindraj/typeql",
-        commit = "169119466fb2c60e23339c99477c3fc2f8826aa0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/vaticle/typeql",
+        commit = "6e64ff0a0c73ee825d7f701b49eaf10dff7c7a33", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/krishnangovindraj/typedb-protocol",
-        commit = "486e9f095cba86abb829b2632c8502822bd7530b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/vaticle/typedb-protocol",
+        commit = "5c073e625770e812e4807419392d7f7261a553fb", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "709d5739148e301ef59db93ac0cfa0b24c6cbe1d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "767bf98fef7383addf42a1ae6e97a44874bb4f0b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/test/behaviour/concept/thing/attribute/AttributeSteps.java
+++ b/test/behaviour/concept/thing/attribute/AttributeSteps.java
@@ -21,7 +21,7 @@
 
 package com.vaticle.typedb.client.test.behaviour.concept.thing.attribute;
 
-import com.vaticle.typedb.client.api.concept.type.AttributeType.ValueType;
+import com.vaticle.typedb.client.api.concept.type.Type.ValueType;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 

--- a/test/behaviour/concept/thing/attribute/AttributeSteps.java
+++ b/test/behaviour/concept/thing/attribute/AttributeSteps.java
@@ -21,7 +21,7 @@
 
 package com.vaticle.typedb.client.test.behaviour.concept.thing.attribute;
 
-import com.vaticle.typedb.client.api.concept.type.Type.ValueType;
+import com.vaticle.typedb.client.api.concept.Concept.ValueType;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 

--- a/test/behaviour/concept/type/attributetype/AttributeTypeSteps.java
+++ b/test/behaviour/concept/type/attributetype/AttributeTypeSteps.java
@@ -21,8 +21,9 @@
 
 package com.vaticle.typedb.client.test.behaviour.concept.type.attributetype;
 
+import com.vaticle.typedb.client.api.concept.Concept;
 import com.vaticle.typedb.client.api.concept.type.AttributeType;
-import com.vaticle.typedb.client.api.concept.type.Type.ValueType;
+import com.vaticle.typedb.client.api.concept.Concept.ValueType;
 import com.vaticle.typedb.client.api.concept.type.Type;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typeql.lang.common.TypeQLToken;
@@ -98,28 +99,28 @@ public class AttributeTypeSteps {
 
     @Then("attribute\\( ?{type_label} ?) as\\( ?{value_type} ?) set regex: {}")
     public void attribute_type_as_value_type_set_regex(String typeLabel, ValueType valueType, String regex) {
-        if (!valueType.equals(Type.ValueType.STRING)) fail();
+        if (!valueType.equals(Concept.ValueType.STRING)) fail();
         AttributeType attributeType = attribute_type_as_value_type(typeLabel, valueType);
         attributeType.asString().asRemote(tx()).setRegex(regex);
     }
 
     @Then("attribute\\( ?{type_label} ?) as\\( ?{value_type} ?) unset regex")
     public void attribute_type_as_value_type_unset_regex(String typeLabel, AttributeType.ValueType valueType) {
-        if (!valueType.equals(Type.ValueType.STRING)) fail();
+        if (!valueType.equals(Concept.ValueType.STRING)) fail();
         AttributeType attributeType = attribute_type_as_value_type(typeLabel, valueType);
         attributeType.asString().asRemote(tx()).setRegex(null);
     }
 
     @Then("attribute\\( ?{type_label} ?) as\\( ?{value_type} ?) get regex: {}")
     public void attribute_type_as_value_type_get_regex(String typeLabel, ValueType valueType, String regex) {
-        if (!valueType.equals(Type.ValueType.STRING)) fail();
+        if (!valueType.equals(Concept.ValueType.STRING)) fail();
         AttributeType attributeType = attribute_type_as_value_type(typeLabel, valueType);
         assertEquals(regex, attributeType.asString().asRemote(tx()).getRegex());
     }
 
     @Then("attribute\\( ?{type_label} ?) as\\( ?{value_type} ?) does not have any regex")
     public void attribute_type_as_value_type_does_not_have_any_regex(String typeLabel, AttributeType.ValueType valueType) {
-        if (!valueType.equals(Type.ValueType.STRING)) fail();
+        if (!valueType.equals(Concept.ValueType.STRING)) fail();
         AttributeType attributeType = attribute_type_as_value_type(typeLabel, valueType);
         assertNull(attributeType.asString().asRemote(tx()).getRegex());
     }

--- a/test/behaviour/concept/type/attributetype/AttributeTypeSteps.java
+++ b/test/behaviour/concept/type/attributetype/AttributeTypeSteps.java
@@ -22,7 +22,7 @@
 package com.vaticle.typedb.client.test.behaviour.concept.type.attributetype;
 
 import com.vaticle.typedb.client.api.concept.type.AttributeType;
-import com.vaticle.typedb.client.api.concept.type.AttributeType.ValueType;
+import com.vaticle.typedb.client.api.concept.type.Type.ValueType;
 import com.vaticle.typedb.client.api.concept.type.Type;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typeql.lang.common.TypeQLToken;
@@ -98,28 +98,28 @@ public class AttributeTypeSteps {
 
     @Then("attribute\\( ?{type_label} ?) as\\( ?{value_type} ?) set regex: {}")
     public void attribute_type_as_value_type_set_regex(String typeLabel, ValueType valueType, String regex) {
-        if (!valueType.equals(ValueType.STRING)) fail();
+        if (!valueType.equals(Type.ValueType.STRING)) fail();
         AttributeType attributeType = attribute_type_as_value_type(typeLabel, valueType);
         attributeType.asString().asRemote(tx()).setRegex(regex);
     }
 
     @Then("attribute\\( ?{type_label} ?) as\\( ?{value_type} ?) unset regex")
     public void attribute_type_as_value_type_unset_regex(String typeLabel, AttributeType.ValueType valueType) {
-        if (!valueType.equals(AttributeType.ValueType.STRING)) fail();
+        if (!valueType.equals(Type.ValueType.STRING)) fail();
         AttributeType attributeType = attribute_type_as_value_type(typeLabel, valueType);
         attributeType.asString().asRemote(tx()).setRegex(null);
     }
 
     @Then("attribute\\( ?{type_label} ?) as\\( ?{value_type} ?) get regex: {}")
     public void attribute_type_as_value_type_get_regex(String typeLabel, ValueType valueType, String regex) {
-        if (!valueType.equals(ValueType.STRING)) fail();
+        if (!valueType.equals(Type.ValueType.STRING)) fail();
         AttributeType attributeType = attribute_type_as_value_type(typeLabel, valueType);
         assertEquals(regex, attributeType.asString().asRemote(tx()).getRegex());
     }
 
     @Then("attribute\\( ?{type_label} ?) as\\( ?{value_type} ?) does not have any regex")
     public void attribute_type_as_value_type_does_not_have_any_regex(String typeLabel, AttributeType.ValueType valueType) {
-        if (!valueType.equals(AttributeType.ValueType.STRING)) fail();
+        if (!valueType.equals(Type.ValueType.STRING)) fail();
         AttributeType attributeType = attribute_type_as_value_type(typeLabel, valueType);
         assertNull(attributeType.asString().asRemote(tx()).getRegex());
     }

--- a/test/behaviour/config/Parameters.java
+++ b/test/behaviour/config/Parameters.java
@@ -22,8 +22,8 @@
 package com.vaticle.typedb.client.test.behaviour.config;
 
 import com.vaticle.typedb.client.api.TypeDBTransaction;
-import com.vaticle.typedb.client.api.concept.type.Type.ValueType;
-import com.vaticle.typedb.client.api.concept.type.Type;
+import com.vaticle.typedb.client.api.concept.Concept;
+import com.vaticle.typedb.client.api.concept.Concept.ValueType;
 import com.vaticle.typedb.client.common.Label;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typeql.lang.common.TypeQLToken;
@@ -95,15 +95,15 @@ public class Parameters {
     public ValueType value_type(String type) {
         switch (type) {
             case "long":
-                return Type.ValueType.LONG;
+                return Concept.ValueType.LONG;
             case "double":
-                return Type.ValueType.DOUBLE;
+                return Concept.ValueType.DOUBLE;
             case "string":
-                return Type.ValueType.STRING;
+                return Concept.ValueType.STRING;
             case "boolean":
-                return Type.ValueType.BOOLEAN;
+                return Concept.ValueType.BOOLEAN;
             case "datetime":
-                return Type.ValueType.DATETIME;
+                return Concept.ValueType.DATETIME;
             default:
                 return null;
         }

--- a/test/behaviour/config/Parameters.java
+++ b/test/behaviour/config/Parameters.java
@@ -22,7 +22,8 @@
 package com.vaticle.typedb.client.test.behaviour.config;
 
 import com.vaticle.typedb.client.api.TypeDBTransaction;
-import com.vaticle.typedb.client.api.concept.type.AttributeType.ValueType;
+import com.vaticle.typedb.client.api.concept.type.Type.ValueType;
+import com.vaticle.typedb.client.api.concept.type.Type;
 import com.vaticle.typedb.client.common.Label;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typeql.lang.common.TypeQLToken;
@@ -94,15 +95,15 @@ public class Parameters {
     public ValueType value_type(String type) {
         switch (type) {
             case "long":
-                return ValueType.LONG;
+                return Type.ValueType.LONG;
             case "double":
-                return ValueType.DOUBLE;
+                return Type.ValueType.DOUBLE;
             case "string":
-                return ValueType.STRING;
+                return Type.ValueType.STRING;
             case "boolean":
-                return ValueType.BOOLEAN;
+                return Type.ValueType.BOOLEAN;
             case "datetime":
-                return ValueType.DATETIME;
+                return Type.ValueType.DATETIME;
             default:
                 return null;
         }

--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -202,6 +202,11 @@ public class TypeQLSteps {
         assertThrows(() -> typeql_match(typeQLQueryStatements));
     }
 
+    @When("typeql match; throws exception containing {string}")
+    public void typeql_match_throws_exception_containing(String typeQLQueryStatements, String error) {
+        assertThrowsWithMessage(() -> typeql_match(typeQLQueryStatements), error);
+    }
+
     @When("get answer of typeql match aggregate")
     public void typeql_match_aggregate(String typeQLQueryStatements) {
         TypeQLMatch.Aggregate typeQLQuery = TypeQL.parseQuery(String.join("\n", typeQLQueryStatements)).asMatchAggregate();

--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -203,7 +203,7 @@ public class TypeQLSteps {
     }
 
     @When("typeql match; throws exception containing {string}")
-    public void typeql_match_throws_exception_containing(String typeQLQueryStatements, String error) {
+    public void typeql_match_throws_exception_containing(String error, String typeQLQueryStatements) {
         assertThrowsWithMessage(() -> typeql_match(typeQLQueryStatements), error);
     }
 

--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -47,9 +47,9 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Optional;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -60,8 +60,8 @@ import static com.vaticle.typedb.client.test.behaviour.connection.ConnectionStep
 import static com.vaticle.typedb.client.test.behaviour.util.Util.assertThrows;
 import static com.vaticle.typedb.client.test.behaviour.util.Util.assertThrowsWithMessage;
 import static com.vaticle.typedb.common.collection.Collections.set;
-import static com.vaticle.typeql.lang.common.TypeQLToken.Annotation.KEY;
 import static com.vaticle.typedb.common.util.Double.equalsApproximate;
+import static com.vaticle.typeql.lang.common.TypeQLToken.Annotation.KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -73,7 +73,7 @@ public class TypeQLSteps {
     private static List<ConceptMapGroup> answerGroups;
     private static List<NumericGroup> numericAnswerGroups;
     private Map<String, Map<String, String>> rules;
-    
+
     public static List<ConceptMap> answers() {
         return answers;
     }
@@ -303,7 +303,7 @@ public class TypeQLSteps {
                 .collect(Collectors.toSet());
 
         assertEquals(String.format("Expected [%d] answer groups, but found [%d].",
-                answerIdentifierGroups.size(), answerGroups.size()),
+                        answerIdentifierGroups.size(), answerGroups.size()),
                 answerIdentifierGroups.size(), answerGroups.size()
         );
 
@@ -316,6 +316,9 @@ public class TypeQLSteps {
                     break;
                 case "key":
                     checker = new KeyUniquenessCheck(identifier[1]);
+                    break;
+                case "attr":
+                    checker = new AttributeValueUniquenessCheck(identifier[1]);
                     break;
                 case "value":
                     checker = new ValueUniquenessCheck(identifier[1]);
@@ -370,6 +373,9 @@ public class TypeQLSteps {
                     break;
                 case "key":
                     checker = new KeyUniquenessCheck(identifier[1]);
+                    break;
+                case "attr":
+                    checker = new AttributeValueUniquenessCheck(identifier[1]);
                     break;
                 case "value":
                     checker = new ValueUniquenessCheck(identifier[1]);
@@ -445,6 +451,11 @@ public class TypeQLSteps {
                     break;
                 case "key":
                     if (!new KeyUniquenessCheck(identifier[1]).check(answer.get(var))) {
+                        return false;
+                    }
+                    break;
+                case "attr":
+                    if (!new AttributeValueUniquenessCheck(identifier[1]).check(answer.get(var))) {
                         return false;
                     }
                     break;
@@ -645,8 +656,8 @@ public class TypeQLSteps {
         }
     }
 
-    public static class ValueUniquenessCheck extends AttributeUniquenessCheck implements UniquenessCheck {
-        ValueUniquenessCheck(String typeAndValue) {
+    public static class AttributeValueUniquenessCheck extends AttributeUniquenessCheck implements UniquenessCheck {
+        AttributeValueUniquenessCheck(String typeAndValue) {
             super(typeAndValue);
         }
 
@@ -724,4 +735,41 @@ public class TypeQLSteps {
         }
     }
 
+    public static class ValueUniquenessCheck implements UniquenessCheck {
+        private final String valueType;
+        private final String value;
+
+        ValueUniquenessCheck(String valueTypeAndValue) {
+            String[] s = valueTypeAndValue.split(":");
+            this.valueType = s[0].toLowerCase().strip();
+            this.value = s[1].strip();
+        }
+
+        public boolean check(Concept concept) {
+            if (!concept.isValue()) {
+                return false;
+            }
+
+            switch (concept.asValue().getValueType()) {
+                case BOOLEAN:
+                    return Boolean.valueOf(value).equals(concept.asValue().asBoolean().getValue());
+                case LONG:
+                    return Long.valueOf(value).equals(concept.asValue().asLong().getValue());
+                case DOUBLE:
+                    return equalsApproximate(Double.parseDouble(value), concept.asValue().asDouble().getValue());
+                case STRING:
+                    return value.equals(concept.asValue().asString().getValue());
+                case DATETIME:
+                    LocalDateTime dateTime;
+                    try {
+                        dateTime = LocalDateTime.parse(value);
+                    } catch (DateTimeParseException e) {
+                        dateTime = LocalDate.parse(value).atStartOfDay();
+                    }
+                    return dateTime.equals(concept.asValue().asDateTime().getValue());
+                default:
+                    throw new ScenarioDefinitionException("Unrecognised value type specified in test " + this.valueType);
+            }
+        }
+    }
 }

--- a/test/behaviour/typeql/language/expression/BUILD
+++ b/test/behaviour/typeql/language/expression/BUILD
@@ -30,7 +30,7 @@ typedb_behaviour_java_test(
     ],
     test_class = "com.vaticle.typedb.client.test.behaviour.typeql.language.expression.ExpressionTest",
     data = [
-        "@vaticle_typedb_behaviour//typeql/language:expressions.feature",
+        "@vaticle_typedb_behaviour//typeql/language:expression.feature",
     ],
     typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
     typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",

--- a/test/behaviour/typeql/language/expression/BUILD
+++ b/test/behaviour/typeql/language/expression/BUILD
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+package(default_visibility = ["//visibility:__subpackages__"])
+load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("//test/behaviour:rules.bzl", "typedb_behaviour_java_test")
+
+typedb_behaviour_java_test(
+    name = "test",
+    srcs = [
+        "ExpressionTest.java",
+    ],
+    test_class = "com.vaticle.typedb.client.test.behaviour.typeql.language.expression.ExpressionTest",
+    data = [
+        "@vaticle_typedb_behaviour//typeql/language:expressions.feature",
+    ],
+    typedb_artifact_mac = "@vaticle_typedb_artifact_mac//file",
+    typedb_artifact_linux = "@vaticle_typedb_artifact_linux//file",
+    typedb_artifact_windows = "@vaticle_typedb_artifact_windows//file",
+    typedb_cluster_artifact_mac = "@vaticle_typedb_cluster_artifact_mac//file",
+    typedb_cluster_artifact_linux = "@vaticle_typedb_cluster_artifact_linux//file",
+    typedb_cluster_artifact_windows = "@vaticle_typedb_cluster_artifact_windows//file",
+    connection_steps_core = "//test/behaviour/connection:steps-core",
+    connection_steps_cluster = "//test/behaviour/connection:steps-cluster",
+    steps = [
+        "//test/behaviour/typeql:steps",
+        "//test/behaviour/connection/session:steps",
+    ],
+    deps = [
+        # Internal Package Dependencies
+        "//test/behaviour:behaviour",
+
+        # External dependencies from Maven
+        "@maven//:io_cucumber_cucumber_junit",
+    ],
+    runtime_deps = [
+        "//test/behaviour/config:parameters",
+    ],
+    size = "large",
+    visibility = ["//visibility:public"],
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "apache-header",
+)

--- a/test/behaviour/typeql/language/expression/ExpressionTest.java
+++ b/test/behaviour/typeql/language/expression/ExpressionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.vaticle.typedb.client.test.behaviour.typeql.language.expression;
+
+import com.vaticle.typedb.client.test.behaviour.BehaviourTest;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "com.vaticle.typedb.client.test.behaviour",
+        features = "external/vaticle_typedb_behaviour/typeql/language/expressions.feature",
+        tags = "not @ignore and not @ignore-typedb-client-java"
+)
+public class ExpressionTest extends BehaviourTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test GetTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
+    //    b) Use '//<this>/<package>/<name>:test-cluster' to test against typedb-cluster
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.client.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run TypeDB)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/test/behaviour/typeql/language/expression/ExpressionTest.java
+++ b/test/behaviour/typeql/language/expression/ExpressionTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
         strict = true,
         plugin = "pretty",
         glue = "com.vaticle.typedb.client.test.behaviour",
-        features = "external/vaticle_typedb_behaviour/typeql/language/expressions.feature",
+        features = "external/vaticle_typedb_behaviour/typeql/language/expression.feature",
         tags = "not @ignore and not @ignore-typedb-client-java"
 )
 public class ExpressionTest extends BehaviourTest {

--- a/test/behaviour/util/Util.java
+++ b/test/behaviour/util/Util.java
@@ -40,7 +40,7 @@ public class Util {
             function.run();
             fail();
         } catch (RuntimeException e) {
-            assert (e.toString().toLowerCase().contains(message.toLowerCase()));
+            assert e.toString().contains(message);
         }
     }
 }

--- a/test/behaviour/util/Util.java
+++ b/test/behaviour/util/Util.java
@@ -40,8 +40,7 @@ public class Util {
             function.run();
             fail();
         } catch (RuntimeException e) {
-            System.out.println(e.toString());
-            assert (e.toString().contains(message));
+            assert (e.toString().toLowerCase().contains(message.toLowerCase()));
         }
     }
 }

--- a/test/behaviour/util/Util.java
+++ b/test/behaviour/util/Util.java
@@ -40,7 +40,7 @@ public class Util {
             function.run();
             fail();
         } catch (RuntimeException e) {
-            assert e.toString().contains(message);
+            assert e.toString().toLowerCase().contains(message.toLowerCase());
         }
     }
 }

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -57,7 +57,7 @@ import static com.vaticle.typeql.lang.TypeQL.and;
 import static com.vaticle.typeql.lang.TypeQL.rel;
 import static com.vaticle.typeql.lang.TypeQL.rule;
 import static com.vaticle.typeql.lang.TypeQL.type;
-import static com.vaticle.typeql.lang.TypeQL.var;
+import static com.vaticle.typeql.lang.TypeQL.cVar;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
@@ -97,11 +97,11 @@ public class ClientQueryTest {
             );
             TypeQLDefine ruleQuery = TypeQL.define(rule("infer-parentship-from-mating-and-child-bearing")
                     .when(and(
-                            rel("male-partner", var("male")).rel("female-partner", var("female")).isa("mating"),
-                            var("childbearing").rel("child-bearer").rel("offspring", var("offspring")).isa("child-bearing")))
-                    .then(rel("parent", var("male"))
-                            .rel("parent", var("female"))
-                            .rel("child", var("offspring")).isa("parentship")));
+                            rel("male-partner", cVar("male")).rel("female-partner", cVar("female")).isa("mating"),
+                            cVar("childbearing").rel(cVar("child-bearer")).rel("offspring", cVar("offspring")).isa("child-bearing")))
+                    .then(rel("parent", cVar("male"))
+                            .rel("parent", cVar("female"))
+                            .rel("child", cVar("offspring")).isa("parentship")));
             LOG.info("clientJavaE2E() - define a schema...");
             LOG.info("clientJavaE2E() - '" + defineQuery + "'");
             tx.query().define(defineQuery);
@@ -112,7 +112,7 @@ public class ClientQueryTest {
 
         // TODO: re-enable when match is implemented
 //        localhostTypeDBTX(tx -> {
-//            final TypeQLMatch getThingQuery = TypeQL.match(var("t").sub("thing"));
+//            final TypeQLMatch getThingQuery = TypeQL.match(cVar("t").sub("thing"));
 //            LOG.info("clientJavaE2E() - assert if schema defined...");
 //            LOG.info("clientJavaE2E() - '" + getThingQuery + "'");
 //            final List<String> definedSchema = tx.query().match(getThingQuery).get()
@@ -126,9 +126,9 @@ public class ClientQueryTest {
         localhostTypeDBTX(tx -> {
             String[] names = lionNames();
             TypeQLInsert insertLionQuery = TypeQL.insert(
-                    var().isa("lion").has("name", names[0]),
-                    var().isa("lion").has("name", names[1]),
-                    var().isa("lion").has("name", names[2])
+                    cVar().isa("lion").has("name", names[0]),
+                    cVar().isa("lion").has("name", names[1]),
+                    cVar().isa("lion").has("name", names[2])
             );
             LOG.info("clientJavaE2E() - insert some data...");
             LOG.info("clientJavaE2E() - '" + insertLionQuery + "'");
@@ -142,20 +142,20 @@ public class ClientQueryTest {
 //            final String[] familyMembers = lionNames();
 //            LOG.info("clientJavaE2E() - inserting mating relations...");
 //            final TypeQLInsert insertMatingQuery = TypeQL.match(
-//                    var("lion").isa("lion").has("name", familyMembers[0]),
-//                    var("lioness").isa("lion").has("name", familyMembers[1]))
-//                    .insert(rel("male-partner", "lion").rel("female-partner", var("lioness")).isa("mating"));
+//                    cVar("lion").isa("lion").has("name", familyMembers[0]),
+//                    cVar("lioness").isa("lion").has("name", familyMembers[1]))
+//                    .insert(rel("male-partner", "lion").rel("female-partner", cVar("lioness")).isa("mating"));
 //            LOG.info("clientJavaE2E() - '" + insertMatingQuery + "'");
 //            final long insertedMating = tx.query().insert(insertMatingQuery).get().count();
 //
 //            LOG.info("clientJavaE2E() - inserting child-bearing relations...");
 //            final TypeQLInsert insertChildBearingQuery = TypeQL.match(
-//                    var("lion").isa("lion").has("name", familyMembers[0]),
-//                    var("lioness").isa("lion").has("name", familyMembers[1]),
-//                    var("offspring").isa("lion").has("name", familyMembers[2]),
-//                    var("mating").rel("male-partner", var("lion")).rel("female-partner", var("lioness")).isa("mating")
+//                    cVar("lion").isa("lion").has("name", familyMembers[0]),
+//                    cVar("lioness").isa("lion").has("name", familyMembers[1]),
+//                    cVar("offspring").isa("lion").has("name", familyMembers[2]),
+//                    cVar("mating").rel("male-partner", cVar("lion")).rel("female-partner", cVar("lioness")).isa("mating")
 //            )
-//                    .insert(var("childbearing").rel("child-bearer", var("mating")).rel("offspring", var("offspring")).isa("child-bearing"));
+//                    .insert(cVar("childbearing").rel("child-bearer", cVar("mating")).rel("offspring", cVar("offspring")).isa("child-bearing"));
 //            LOG.info("clientJavaE2E() - '" + insertChildBearingQuery + "'");
 //            final long insertedChildBearing = tx.query().insert(insertChildBearingQuery).get().count();
 //
@@ -169,20 +169,20 @@ public class ClientQueryTest {
 //
 //        localhostTypeDBTX(tx -> {
 //            LOG.info("clientJavaE2E() - execute match get on the lion instances...");
-//            final TypeQLMatch getLionQuery = TypeQL.match(var("p").isa("lion").has("name", var("n")));
+//            final TypeQLMatch getLionQuery = TypeQL.match(cVar("p").isa("lion").has("name", cVar("n")));
 //            LOG.info("clientJavaE2E() - '" + getLionQuery + "'");
 //            final Stream<ConceptMap> insertedLions = tx.query().match(getLionQuery).get();
 //            final List<String> insertedNames = insertedLions.map(answer -> answer.get("n").asThing().asAttribute().asString().getValue()).collect(Collectors.toList());
 //            assertThat(insertedNames, containsInAnyOrder(lionNames()));
 //
 //            LOG.info("clientJavaE2E() - execute match get on the mating relations...");
-//            final TypeQLMatch getMatingQuery = TypeQL.match(var("m").isa("mating"));
+//            final TypeQLMatch getMatingQuery = TypeQL.match(cVar("m").isa("mating"));
 //            LOG.info("clientJavaE2E() - '" + getMatingQuery + "'");
 //            final long insertedMating = tx.query().match(getMatingQuery).get().count();
 //            assertEquals(1, insertedMating);
 //
 //            LOG.info("clientJavaE2E() - execute match get on the child-bearing...");
-//            final TypeQLMatch getChildBearingQuery = TypeQL.match(var("cb").isa("child-bearing"));
+//            final TypeQLMatch getChildBearingQuery = TypeQL.match(cVar("cb").isa("child-bearing"));
 //            LOG.info("clientJavaE2E() - '" + getChildBearingQuery + "'");
 //            final long insertedChildBearing = tx.query().match(getChildBearingQuery).get().count();
 //            assertEquals(1, insertedChildBearing);
@@ -192,9 +192,9 @@ public class ClientQueryTest {
 //        localhostTypeDBTX(tx -> {
 //            LOG.info("clientJavaE2E() - match get inferred relations...");
 //            final TypeQLMatch getParentship = TypeQL.match(
-//                    var("parentship")
-//                            .rel("parent", var("parent"))
-//                            .rel("child", var("child"))
+//                    cVar("parentship")
+//                            .rel("parent", cVar("parent"))
+//                            .rel("child", cVar("child"))
 //                            .isa("parentship"));
 //            LOG.info("clientJavaE2E() - '" + getParentship + "'");
 //            final long parentship = tx.query().match(getParentship).get().count();
@@ -206,7 +206,7 @@ public class ClientQueryTest {
         // TODO: uncomment when aggregate is implemented
 //        localhostTypeDBTX(tx -> {
 //            LOG.info("clientJavaE2E() - match aggregate...");
-//            TypeQLMatch.Aggregate aggregateQuery = TypeQL.match(var("p").isa("lion")).count();
+//            TypeQLMatch.Aggregate aggregateQuery = TypeQL.match(cVar("p").isa("lion")).count();
 //            LOG.info("clientJavaE2E() - '" + aggregateQuery + "'");
 //            int aggregateCount = tx.query().aggregate(aggregateQuery).get().get(0).number().intValue();
 //            assertThat(aggregateCount, equalTo(lionNames().length));
@@ -226,10 +226,10 @@ public class ClientQueryTest {
         // TODO: uncomment when match is implemented
 //        localhostTypeDBTX(tx -> {
 //            LOG.info("clientJavaE2E() - match delete...");
-//            TypeQLDelete deleteQuery = TypeQL.match(var("m").isa("mating")).delete(var("m").isa("mating"));
+//            TypeQLDelete deleteQuery = TypeQL.match(cVar("m").isa("mating")).delete(cVar("m").isa("mating"));
 //            LOG.info("clientJavaE2E() - '" + deleteQuery + "'");
 //            tx.query().delete(deleteQuery).get();
-//            final long matings = tx.query().match(TypeQL.match(var("m").isa("mating"))).get().count();
+//            final long matings = tx.query().match(TypeQL.match(cVar("m").isa("mating"))).get().count();
 //            assertEquals(0, matings);
 //            LOG.info("clientJavaE2E() - done.");
 //        });
@@ -294,15 +294,15 @@ public class ClientQueryTest {
         localhostTypeDBTX(tx -> {
             String[] commits = commitSHAs();
             TypeQLInsert insertCommitQuery = TypeQL.insert(
-                    var().isa("commit").has("symbol", commits[0]),
-                    var().isa("commit").has("symbol", commits[1]),
-                    var().isa("commit").has("symbol", commits[3]),
-                    var().isa("commit").has("symbol", commits[4]),
-                    var().isa("commit").has("symbol", commits[5]),
-                    var().isa("commit").has("symbol", commits[6]),
-                    var().isa("commit").has("symbol", commits[7]),
-                    var().isa("commit").has("symbol", commits[8]),
-                    var().isa("commit").has("symbol", commits[9])
+                    cVar().isa("commit").has("symbol", commits[0]),
+                    cVar().isa("commit").has("symbol", commits[1]),
+                    cVar().isa("commit").has("symbol", commits[3]),
+                    cVar().isa("commit").has("symbol", commits[4]),
+                    cVar().isa("commit").has("symbol", commits[5]),
+                    cVar().isa("commit").has("symbol", commits[6]),
+                    cVar().isa("commit").has("symbol", commits[7]),
+                    cVar().isa("commit").has("symbol", commits[8]),
+                    cVar().isa("commit").has("symbol", commits[9])
             );
 
             LOG.info("clientJavaE2E() - insert commit data...");
@@ -314,11 +314,11 @@ public class ClientQueryTest {
 
         localhostTypeDBTX(tx -> {
             TypeQLInsert insertWorkflowQuery = TypeQL.insert(
-                    var().isa("workflow")
+                    cVar().isa("workflow")
                             .has("name", "workflow-A")
                             .has("status", "running")
                             .has("latest", true),
-                    var().isa("workflow")
+                    cVar().isa("workflow")
                             .has("name", "workflow-B")
                             .has("status", "finished")
                             .has("latest", false)
@@ -333,10 +333,10 @@ public class ClientQueryTest {
 
         localhostTypeDBTX(tx -> {
             TypeQLInsert insertPipelineQuery = TypeQL.insert(
-                    var().isa("pipeline")
+                    cVar().isa("pipeline")
                             .has("name", "pipeline-A")
                             .has("latest", true),
-                    var().isa("pipeline")
+                    cVar().isa("pipeline")
                             .has("name", "pipeline-B")
                             .has("latest", false)
             );
@@ -354,11 +354,11 @@ public class ClientQueryTest {
 
             for (int i = 0; i < commitShas.length / 2; i++) {
                 TypeQLInsert insertPipelineAutomationQuery = TypeQL.match(
-                                var("commit").isa("commit").has("symbol", commitShas[i]),
-                                var("pipeline").isa("pipeline").has("name", "pipeline-A")
+                                cVar("commit").isa("commit").has("symbol", commitShas[i]),
+                                cVar("pipeline").isa("pipeline").has("name", "pipeline-A")
                         )
                         .insert(
-                                rel("pipeline", "pipeline").rel("trigger", "commit").isa("pipeline-automation")
+                                rel("pipeline", cVar("pipeline")).rel("trigger", cVar("commit")).isa("pipeline-automation")
                         );
                 LOG.info("clientJavaE2E() - '" + insertPipelineAutomationQuery + "'");
                 List<ConceptMap> x = tx.query().insert(insertPipelineAutomationQuery).collect(toList());
@@ -367,11 +367,11 @@ public class ClientQueryTest {
 
             for (int i = commitShas.length / 2; i < commitShas.length; i++) {
                 TypeQLInsert insertPipelineAutomationQuery = TypeQL.match(
-                                var("commit").isa("commit").has("symbol", commitShas[i]),
-                                var("pipeline").isa("pipeline").has("name", "pipeline-B")
+                                cVar("commit").isa("commit").has("symbol", commitShas[i]),
+                                cVar("pipeline").isa("pipeline").has("name", "pipeline-B")
                         )
                         .insert(
-                                rel("pipeline", "pipeline").rel("trigger", "commit").isa("pipeline-automation")
+                                rel("pipeline", cVar("pipeline")).rel("trigger", cVar("commit")).isa("pipeline-automation")
                         );
                 LOG.info("clientJavaE2E() - '" + insertPipelineAutomationQuery + "'");
                 List<ConceptMap> x = tx.query().insert(insertPipelineAutomationQuery).collect(toList());
@@ -386,14 +386,14 @@ public class ClientQueryTest {
             LOG.info("clientJavaE2E() - inserting pipeline-automation relations...");
 
             TypeQLInsert insertPipelineWorkflowQuery = TypeQL.match(
-                            var("pipelineA").isa("pipeline").has("name", "pipeline-A"),
-                            var("workflowA").isa("workflow").has("name", "workflow-A"),
-                            var("pipelineB").isa("pipeline").has("name", "pipeline-B"),
-                            var("workflowB").isa("workflow").has("name", "workflow-B")
+                            cVar("pipelineA").isa("pipeline").has("name", "pipeline-A"),
+                            cVar("workflowA").isa("workflow").has("name", "workflow-A"),
+                            cVar("pipelineB").isa("pipeline").has("name", "pipeline-B"),
+                            cVar("workflowB").isa("workflow").has("name", "workflow-B")
                     )
                     .insert(
-                            rel("pipeline", "pipelineA").rel("workflow", "workflowA").isa("pipeline-workflow"),
-                            rel("pipeline", "pipelineB").rel("workflow", "workflowB").isa("pipeline-workflow")
+                            rel("pipeline", cVar("pipelineA")).rel("workflow", cVar("workflowA")).isa("pipeline-workflow"),
+                            rel("pipeline", cVar("pipelineB")).rel("workflow", cVar("workflowB")).isa("pipeline-workflow")
                     );
             LOG.info("clientJavaE2E() - '" + insertPipelineWorkflowQuery + "'");
             List<ConceptMap> x = tx.query().insert(insertPipelineWorkflowQuery).collect(toList());


### PR DESCRIPTION
## What is the goal of this PR?

Introduce the 'Value' type, which is returned as the result of an expression's computation. This change follows from https://github.com/vaticle/typeql/pull/260, which outlines the capabilities of the new expression syntax.

Values (representing any of Long, Double, Boolean, String, or DateTime) are returned as part of `ConceptMap` answers and are subtypes of `Concept` for the time being. Their main API is made of the `.getValue()` method and `.getValueType()` method, along with all the standard safe downcasting methods to convert a `Concept` into a `Value`, using `Concept.isValue()` and `Concept.asValue()`.

We also move the import location of `ValueType` from being nested in `AttributeType` to `Concept`.

## What are the changes implemented in this PR?
* Introduces the `Value` concept and the required `ValueImpl` that implements it
* Refactor `ValueType` to no longer live within `AttributeType` - now it exists in `Concept.ValueType`
* Updates the test framework for tests involving values, including the new `ExpressionTest` behaviour scenarios, which we also add to CI