### PR TITLE
Add behaviour test step definition for retrieving the currently connected user

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -52,8 +52,8 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/jamesreprise/typedb-behaviour",
-        commit = "04973b8312a78b1445ab6011f3b094585cfd9acf" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "fbba9fc19042460760b852b765d356c9b3f4ebf0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -52,8 +52,8 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "b4cbdd3aaf28428608fc88eae0852425df57fe25" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/jamesreprise/typedb-behaviour",
+        commit = "455159dd1cdd8ab49e72e10d4c464209f2181424" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -53,7 +53,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/jamesreprise/typedb-behaviour",
-        commit = "455159dd1cdd8ab49e72e10d4c464209f2181424" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "04973b8312a78b1445ab6011f3b094585cfd9acf" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/test/behaviour/connection/user/UserSteps.java
+++ b/test/behaviour/connection/user/UserSteps.java
@@ -47,7 +47,7 @@ public class UserSteps {
         return users.contains(username);
     }
 
-    @Then("user get self")
+    @Then("get connected user")
     public void users_get() {
         User ignored = getClient().user();
     }

--- a/test/behaviour/connection/user/UserSteps.java
+++ b/test/behaviour/connection/user/UserSteps.java
@@ -47,6 +47,11 @@ public class UserSteps {
         return users.contains(username);
     }
 
+    @Then("user get self")
+    public void users_get() {
+        User ignored = getClient().user();
+    }
+
     @Then("users get user: {word}")
     public void users_get(String username) {
         User ignored = getClient().users().get(username);

--- a/test/behaviour/connection/user/UserSteps.java
+++ b/test/behaviour/connection/user/UserSteps.java
@@ -48,7 +48,7 @@ public class UserSteps {
     }
 
     @Then("get connected user")
-    public void users_get() {
+    public void get_connected_user() {
         User ignored = getClient().user();
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We've added a behaviour test step `get connected user` in line with changes made in https://github.com/vaticle/typedb-behaviour/pull/247

## What are the changes implemented in this PR?

Added user step: `get connected user`.