### PR TITLE
Check BDD value equality using native types

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -32,7 +32,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.17.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "9372dfb227d54c6eb631eed02e67f250e55e657e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typeql():

--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -666,7 +666,7 @@ public class TypeQLSteps {
                 case LONG:
                     return value.equals(attribute.asLong().getValue().toString());
                 case DOUBLE:
-                    return precisionEquals(Double.parseDouble(value),  attribute.asDouble().getValue(), 1e9);
+                    return precisionEquals(Double.parseDouble(value), attribute.asDouble().getValue());
                 case STRING:
                     return value.equals(attribute.asString().getValue());
                 case DATETIME:
@@ -707,7 +707,7 @@ public class TypeQLSteps {
                     case LONG:
                         return value.equals(key.asLong().getValue().toString());
                     case DOUBLE:
-                        return precisionEquals(Double.parseDouble(value),  key.asDouble().getValue(), 1e9);
+                        return precisionEquals(Double.parseDouble(value), key.asDouble().getValue());
                     case STRING:
                         return value.equals(key.asString().getValue());
                     case DATETIME:
@@ -727,7 +727,7 @@ public class TypeQLSteps {
         }
     }
 
-    private static Boolean precisionEquals(Double a, Double b, Double epsilon) {
-        return Math.abs(a - b) < epsilon;
+    private static Boolean precisionEquals(Double a, Double b) {
+        return Math.abs(a - b) / Math.abs(a) < 1.0e6;
     }
 }

--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -697,12 +697,11 @@ public class TypeQLSteps {
                 return false;
             }
 
-            Optional<? extends Attribute<?>> opt_key = concept.asThing().asRemote(tx()).getHas(set(KEY))
+            Optional<? extends Attribute<?>> keyOpt = concept.asThing().asRemote(tx()).getHas(set(KEY))
                     .filter(attr -> attr.getType().getLabel().equals(type)).findFirst();
-            if (opt_key.isEmpty())
-                return false;
+            if (keyOpt.isEmpty()) return false;
 
-            Attribute<?> key = opt_key.get().asAttribute();
+            Attribute<?> key = keyOpt.get().asAttribute();
             switch (key.getType().getValueType()) {
                 case BOOLEAN:
                     return Boolean.valueOf(value).equals(key.asBoolean().getValue());

--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -62,8 +62,6 @@ import static com.vaticle.typedb.client.test.behaviour.util.Util.assertThrowsWit
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Annotation.KEY;
 import static com.vaticle.typedb.common.util.Double.equalsApproximate;
-import static com.vaticle.typedb.common.collection.Collections.set;
-import static com.vaticle.typeql.lang.common.TypeQLToken.Annotation.KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -695,9 +693,7 @@ public class TypeQLSteps {
 
         @Override
         public boolean check(Concept concept) {
-            if (!concept.isThing()) {
-                return false;
-            }
+            if (!concept.isThing()) return false;
 
             Optional<? extends Attribute<?>> keyOpt = concept.asThing().asRemote(tx()).getHas(set(KEY))
                     .filter(attr -> attr.getType().getLabel().equals(type)).findFirst();

--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -62,6 +62,8 @@ import static com.vaticle.typedb.client.test.behaviour.util.Util.assertThrowsWit
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Annotation.KEY;
 import static com.vaticle.typedb.common.util.Double.equalsApproximate;
+import static com.vaticle.typedb.common.collection.Collections.set;
+import static com.vaticle.typeql.lang.common.TypeQLToken.Annotation.KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -60,6 +60,7 @@ import static com.vaticle.typedb.client.test.behaviour.util.Util.assertThrows;
 import static com.vaticle.typedb.client.test.behaviour.util.Util.assertThrowsWithMessage;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Annotation.KEY;
+import static com.vaticle.typedb.common.util.Double.equalsApproximate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -662,11 +663,11 @@ public class TypeQLSteps {
 
             switch (attributeType.getValueType()) {
                 case BOOLEAN:
-                    return value.equals(attribute.asBoolean().getValue().toString());
+                    return Boolean.valueOf(value).equals(attribute.asBoolean().getValue());
                 case LONG:
-                    return value.equals(attribute.asLong().getValue().toString());
+                    return Long.valueOf(value).equals(attribute.asLong().getValue());
                 case DOUBLE:
-                    return precisionEquals(Double.parseDouble(value), attribute.asDouble().getValue());
+                    return equalsApproximate(Double.parseDouble(value), attribute.asDouble().getValue());
                 case STRING:
                     return value.equals(attribute.asString().getValue());
                 case DATETIME:
@@ -703,11 +704,11 @@ public class TypeQLSteps {
                     continue;
                 switch (key.getType().getValueType()) {
                     case BOOLEAN:
-                        return value.equals(key.asBoolean().getValue().toString());
+                        return Boolean.valueOf(value).equals(key.asBoolean().getValue());
                     case LONG:
-                        return value.equals(key.asLong().getValue().toString());
+                        return Long.valueOf(value).equals(key.asLong().getValue());
                     case DOUBLE:
-                        return precisionEquals(Double.parseDouble(value), key.asDouble().getValue());
+                        return equalsApproximate(Double.parseDouble(value), key.asDouble().getValue());
                     case STRING:
                         return value.equals(key.asString().getValue());
                     case DATETIME:
@@ -727,7 +728,4 @@ public class TypeQLSteps {
         }
     }
 
-    private static Boolean precisionEquals(Double a, Double b) {
-        return Math.abs(a - b) / Math.abs(a) < 1.0e6;
-    }
 }


### PR DESCRIPTION
## What is the goal of this PR?

In BDD steps implementation we checked the equality of all values through the conversion to `String`s. It might be incorrect when comparing `Double`s especially if one of these values is a result of arithmetics. 
Now we compare `Double`s by their absolute error. 
For consistency we compare all values using their native types equality.

## What are the changes implemented in this PR?

- We modified `ValueUniquenessCheck` class in order to compare values using their native types equality.
- We modified `KeyUniquenessCheck` class: we find the desired key attribute label and compare each type immediately instead of converting all values to `String`.
