### PR TITLE
Introduce protocol versioning

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -28,40 +28,42 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
     }
 
     public static class Client extends ErrorMessage {
+        public static final Client RPC_METHOD_UNAVAILABLE =
+                new Client(1, "The server does not support this method, please check the client-server compatibility.\n'%s'.");
         public static final Client CLIENT_CLOSED =
-                new Client(1, "The client has been closed and no further operation is allowed.");
+                new Client(2, "The client has been closed and no further operation is allowed.");
         public static final Client SESSION_CLOSED =
-                new Client(2, "The session has been closed and no further operation is allowed.");
+                new Client(3, "The session has been closed and no further operation is allowed.");
         public static final Client TRANSACTION_CLOSED =
-                new Client(3, "The transaction has been closed and no further operation is allowed.");
+                new Client(4, "The transaction has been closed and no further operation is allowed.");
         public static final Client TRANSACTION_CLOSED_WITH_ERRORS =
-                new Client(4, "The transaction has been closed with error(s): \n%s.");
+                new Client(5, "The transaction has been closed with error(s): \n%s.");
         public static final Client UNABLE_TO_CONNECT =
-                new Client(5, "Unable to connect to TypeDB server.");
+                new Client(6, "Unable to connect to TypeDB server.");
         public static final Client NEGATIVE_VALUE_NOT_ALLOWED =
-                new Client(6, "Value cannot be less than 1, was: '%d'.");
+                new Client(7, "Value cannot be less than 1, was: '%d'.");
         public static final Client MISSING_DB_NAME =
-                new Client(7, "Database name cannot be null.");
+                new Client(8, "Database name cannot be null.");
         public static final Client DB_DOES_NOT_EXIST =
-                new Client(8, "The database '%s' does not exist.");
+                new Client(9, "The database '%s' does not exist.");
         public static final Client MISSING_RESPONSE =
-                new Client(9, "Unexpected empty response for request ID '%s'.");
+                new Client(10, "Unexpected empty response for request ID '%s'.");
         public static final Client UNKNOWN_REQUEST_ID =
-                new Client(10, "Received a response with unknown request id '%s':\n%s");
+                new Client(11, "Received a response with unknown request id '%s':\n%s");
         public static final Client CLUSTER_NO_PRIMARY_REPLICA_YET =
-                new Client(11, "No replica has been marked as the primary replica for latest known term '%d'.");
+                new Client(12, "No replica has been marked as the primary replica for latest known term '%d'.");
         public static final Client CLUSTER_UNABLE_TO_CONNECT =
-                new Client(12, "Unable to connect to TypeDB Cluster. Attempted connecting to the cluster members, but none are available: '%s'.");
+                new Client(13, "Unable to connect to TypeDB Cluster. Attempted connecting to the cluster members, but none are available: '%s'.");
         public static final Client CLUSTER_REPLICA_NOT_PRIMARY =
-                new Client(13, "The replica is not the primary replica.");
+                new Client(14, "The replica is not the primary replica.");
         public static final Client CLUSTER_ALL_NODES_FAILED =
-                new Client(14, "Attempted connecting to all cluster members, but the following errors occurred: \n%s.");
+                new Client(15, "Attempted connecting to all cluster members, but the following errors occurred: \n%s.");
         public static final Client CLUSTER_USER_DOES_NOT_EXIST =
-                new Client(15, "The user '%s' does not exist.");
+                new Client(16, "The user '%s' does not exist.");
         public static final ErrorMessage CLUSTER_TOKEN_CREDENTIAL_INVALID =
-                new Client(16, "Invalid token credential.");
+                new Client(17, "Invalid token credential.");
         public static final ErrorMessage CLUSTER_PASSWORD_CREDENTIAL_EXPIRED =
-                new Client(17, "Expired password credential.");
+                new Client(18, "Expired password credential.");
 
         private static final String codePrefix = "CLI";
         private static final String messagePrefix = "Client Error";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -29,7 +29,7 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
 
     public static class Client extends ErrorMessage {
         public static final Client RPC_METHOD_UNAVAILABLE =
-                new Client(1, "The server does not support this method, please check the client-server compatibility.\n'%s'.");
+                new Client(1, "The server does not support this method, please check the client-server compatibility:\n'%s'.");
         public static final Client CLIENT_CLOSED =
                 new Client(2, "The client has been closed and no further operation is allowed.");
         public static final Client SESSION_CLOSED =

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -28,12 +28,14 @@ import com.vaticle.typedb.protocol.ClusterDatabaseProto;
 import com.vaticle.typedb.protocol.ClusterServerProto;
 import com.vaticle.typedb.protocol.ClusterUserProto;
 import com.vaticle.typedb.protocol.ConceptProto;
+import com.vaticle.typedb.protocol.ConnectionProto;
 import com.vaticle.typedb.protocol.CoreDatabaseProto;
 import com.vaticle.typedb.protocol.LogicProto;
 import com.vaticle.typedb.protocol.OptionsProto;
 import com.vaticle.typedb.protocol.QueryProto;
 import com.vaticle.typedb.protocol.SessionProto;
 import com.vaticle.typedb.protocol.TransactionProto;
+import com.vaticle.typedb.protocol.VersionProto;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -171,6 +173,13 @@ public class RequestBuilder {
 
         public static class Database {
 
+        }
+    }
+
+    public static class Connection {
+
+        public static ConnectionProto.Connection.Open.Req openReq() {
+            return ConnectionProto.Connection.Open.Req.newBuilder().setVersion(VersionProto.Version.VERSION).build();
         }
     }
 

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -179,7 +179,9 @@ public class RequestBuilder {
     public static class Connection {
 
         public static ConnectionProto.Connection.Open.Req openReq() {
-            return ConnectionProto.Connection.Open.Req.newBuilder().setVersion(VersionProto.Version.VERSION).build();
+            return ConnectionProto.Connection.Open.Req.newBuilder()
+                    .setVersion(VersionProto.Version.VERSION)
+                    .build();
         }
     }
 

--- a/common/rpc/TypeDBStub.java
+++ b/common/rpc/TypeDBStub.java
@@ -35,6 +35,8 @@ import java.util.function.Supplier;
 
 public abstract class TypeDBStub {
 
+    ConnectionProto
+
     public CoreDatabaseProto.CoreDatabaseManager.Contains.Res databasesContains(CoreDatabaseProto.CoreDatabaseManager.Contains.Req request) {
         return resilientCall(() -> blockingStub().databasesContains(request));
     }

--- a/common/rpc/TypeDBStub.java
+++ b/common/rpc/TypeDBStub.java
@@ -22,6 +22,7 @@
 package com.vaticle.typedb.client.common.rpc;
 
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
+import com.vaticle.typedb.protocol.ConnectionProto;
 import com.vaticle.typedb.protocol.CoreDatabaseProto;
 import com.vaticle.typedb.protocol.SessionProto;
 import com.vaticle.typedb.protocol.TransactionProto;
@@ -35,7 +36,9 @@ import java.util.function.Supplier;
 
 public abstract class TypeDBStub {
 
-    ConnectionProto
+    public ConnectionProto.Connection.Open.Res connectionOpen(ConnectionProto.Connection.Open.Req request) {
+        return resilientCall(() -> blockingStub().connectionOpen(request));
+    }
 
     public CoreDatabaseProto.CoreDatabaseManager.Contains.Res databasesContains(CoreDatabaseProto.CoreDatabaseManager.Contains.Req request) {
         return resilientCall(() -> blockingStub().databasesContains(request));

--- a/connection/TypeDBClientImpl.java
+++ b/connection/TypeDBClientImpl.java
@@ -61,19 +61,6 @@ public abstract class TypeDBClientImpl implements TypeDBClient {
         else return (int) Math.ceil(cores / 4.0);
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    protected void validateConnectionOrThrow() throws TypeDBClientException { // TODO: we should throw checked exception
-        try {
-            // TODO: This is hacky patch. We know that databaseMgr.all() will throw an exception if connection has not been
-            //       established. But we should replace this code to perform the check in a more meaningful way. This method
-            //       should naturally be replaced once we implement a new client pulse architecture.
-            databaseMgr.all();
-        } catch (Exception e){
-            close();
-            throw e;
-        }
-    }
-
     @Override
     public boolean isOpen() {
         return !channel().isShutdown();

--- a/connection/cluster/ClusterClient.java
+++ b/connection/cluster/ClusterClient.java
@@ -93,17 +93,15 @@ public class ClusterClient implements TypeDBClient.Cluster {
         Map<String, ClusterServerClient> clients = new HashMap<>();
         boolean available = false;
         for (String address : addresses) {
-            ClusterServerClient client = new ClusterServerClient(address, credential, parallelisation);
             try {
-                client.validateConnectionOrThrow();
+                ClusterServerClient client = new ClusterServerClient(address, credential, parallelisation);
+                clients.put(address, client);
                 available = true;
             } catch (TypeDBClientException e) {
                 // do nothing
             }
-            clients.put(address, client);
         }
         if (!available) throw new TypeDBClientException(CLUSTER_UNABLE_TO_CONNECT, String.join(",", addresses));
-
         return clients;
     }
 

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -51,11 +51,13 @@ class ClusterServerClient extends TypeDBClientImpl {
         this.address = address;
         channel = createManagedChannel(address, credential);
         stub = new ClusterServerStub(channel, credential);
-    }
-
-    @Override
-    public void validateConnectionOrThrow() throws TypeDBClientException {
-        super.validateConnectionOrThrow();
+        try {
+            stub.
+            // TODO: call open connection
+        } catch (Exception e){
+            close();
+            throw e;
+        }
     }
 
     private ManagedChannel createManagedChannel(String address, TypeDBCredential credential) {

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -36,6 +36,7 @@ import javax.net.ssl.SSLException;
 import java.util.Set;
 
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.ServerManager.allReq;
+import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Connection.openReq;
 import static java.util.stream.Collectors.toSet;
 
 class ClusterServerClient extends TypeDBClientImpl {
@@ -52,8 +53,7 @@ class ClusterServerClient extends TypeDBClientImpl {
         channel = createManagedChannel(address, credential);
         stub = new ClusterServerStub(channel, credential);
         try {
-            stub.
-            // TODO: call open connection
+            stub.connectionOpen(openReq());
         } catch (Exception e){
             close();
             throw e;

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -54,7 +54,7 @@ class ClusterServerClient extends TypeDBClientImpl {
         stub = new ClusterServerStub(channel, credential);
         try {
             stub.connectionOpen(openReq());
-        } catch (Exception e){
+        } catch (Exception e) {
             close();
             throw e;
         }

--- a/connection/core/CoreClient.java
+++ b/connection/core/CoreClient.java
@@ -39,7 +39,13 @@ public class CoreClient extends TypeDBClientImpl {
         super(parallelisation);
         channel = NettyChannelBuilder.forTarget(address).usePlaintext().build();
         stub = CoreStub.create(channel);
-        validateConnectionOrThrow();
+        try {
+            stub.
+            // TODO: call open connection
+        } catch (Exception e) {
+            close();
+            throw e;
+        }
     }
 
     @Override

--- a/connection/core/CoreClient.java
+++ b/connection/core/CoreClient.java
@@ -26,6 +26,8 @@ import com.vaticle.typedb.client.connection.TypeDBClientImpl;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.NettyChannelBuilder;
 
+import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Connection.openReq;
+
 public class CoreClient extends TypeDBClientImpl {
 
     private final ManagedChannel channel;
@@ -40,8 +42,7 @@ public class CoreClient extends TypeDBClientImpl {
         channel = NettyChannelBuilder.forTarget(address).usePlaintext().build();
         stub = CoreStub.create(channel);
         try {
-            stub.
-            // TODO: call open connection
+            stub.connectionOpen(openReq());
         } catch (Exception e) {
             close();
             throw e;

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "816ef97845a9577c2236db69dd94548b5869c083"
+        commit = "ad86a23fb78dda097a8b61b9d01ef68751cb14c1"
     )
 
 def vaticle_typedb_cluster_artifact():
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifact():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "8044753056dd20b8e6bec6f62036eb0003d4ba06",
+        commit = "6e00e0bff33c8c9c90f6393620dd30a9526748c3",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -45,8 +45,8 @@ def vaticle_typeql():
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/vaticle/typedb-protocol",
-        commit = "5c073e625770e812e4807419392d7f7261a553fb", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/flyingsilverfin/typedb-protocol",
+        commit = "d205cea61d427727fe6e73deb57b036f466173b3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -45,8 +45,8 @@ def vaticle_typeql():
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/flyingsilverfin/typedb-protocol",
-        commit = "9aadaf8eda6f3eea707053ad37b82ee59bdd1738", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/vaticle/typedb-protocol",
+        commit = "3c844deff72f1411d8085584b1bdc7311bbeb37a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -46,7 +46,7 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/flyingsilverfin/typedb-protocol",
-        commit = "d205cea61d427727fe6e73deb57b036f466173b3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "9aadaf8eda6f3eea707053ad37b82ee59bdd1738", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():


### PR DESCRIPTION
## What is the goal of this PR?

We use a new protocol API to perform a "connection open". This API does server-side protocol version compatibility checks, and replaces our previous need to get all databases to check that the connection is available.

The user will receive an error about a protocol version mismatch if they are using a client-server combination that are not using exactly compatible protocols. 
1. The server will raise an error if the client tries to connect with a mismatching protocol version
2. The client will raise an error if it tries to connect to the server and the server does not have that API

Both errors imply a client-server mismatch and the error will suggest this as a fix.

This change depends on https://github.com/vaticle/typedb-protocol/pull/185, which means that this client will implement protocol version 1.

## What are the changes implemented in this PR?

* Refactor `validateConnectionOrThrow` into `openConnection`, was then inlined into the constructors of `CoreClient` and `ClusterServerClient`
* Call the new `openConnection` with the protocol Version set when constructing a client
* Throw a useful message if the server returns an `unimplemented` error