### PR TITLE
Split client construction and connection validation

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -30,8 +30,10 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
     public static class Client extends ErrorMessage {
         public static final Client RPC_METHOD_UNAVAILABLE =
                 new Client(1, "The server does not support this method. Please ensure that the TypeDB Client and TypeDB Server versions are compatible:\n'%s'.");
-        public static final Client CLIENT_NOT_OPEN =
-                new Client(2, "The client is not open, no operations are allowed.");
+        public static final Client CLIENT_CLOSED =
+                new Client(2, "The client has been closed and no further operation is allowed.");
+        public static final Client CLIENT_CONNECTION_NOT_VALIDATED =
+                new Client(2, "The client connection has not been validated and cannot be used.");
         public static final Client SESSION_CLOSED =
                 new Client(3, "The session has been closed and no further operation is allowed.");
         public static final Client TRANSACTION_CLOSED =

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -30,8 +30,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
     public static class Client extends ErrorMessage {
         public static final Client RPC_METHOD_UNAVAILABLE =
                 new Client(1, "The server does not support this method. Please ensure that the TypeDB Client and TypeDB Server versions are compatible:\n'%s'.");
-        public static final Client CLIENT_CLOSED =
-                new Client(2, "The client has been closed and no further operation is allowed.");
+        public static final Client CLIENT_NOT_OPEN =
+                new Client(2, "The client is not open, no operations are allowed.");
         public static final Client SESSION_CLOSED =
                 new Client(3, "The session has been closed and no further operation is allowed.");
         public static final Client TRANSACTION_CLOSED =

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -33,39 +33,39 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Client CLIENT_CLOSED =
                 new Client(2, "The client has been closed and no further operation is allowed.");
         public static final Client CLIENT_CONNECTION_NOT_VALIDATED =
-                new Client(2, "The client connection has not been validated and cannot be used.");
+                new Client(3, "The client connection has not been validated and cannot be used.");
         public static final Client SESSION_CLOSED =
-                new Client(3, "The session has been closed and no further operation is allowed.");
+                new Client(4, "The session has been closed and no further operation is allowed.");
         public static final Client TRANSACTION_CLOSED =
-                new Client(4, "The transaction has been closed and no further operation is allowed.");
+                new Client(5, "The transaction has been closed and no further operation is allowed.");
         public static final Client TRANSACTION_CLOSED_WITH_ERRORS =
-                new Client(5, "The transaction has been closed with error(s): \n%s.");
+                new Client(6, "The transaction has been closed with error(s): \n%s.");
         public static final Client UNABLE_TO_CONNECT =
-                new Client(6, "Unable to connect to TypeDB server.");
+                new Client(7, "Unable to connect to TypeDB server.");
         public static final Client NEGATIVE_VALUE_NOT_ALLOWED =
-                new Client(7, "Value cannot be less than 1, was: '%d'.");
+                new Client(8, "Value cannot be less than 1, was: '%d'.");
         public static final Client MISSING_DB_NAME =
-                new Client(8, "Database name cannot be null.");
+                new Client(9, "Database name cannot be null.");
         public static final Client DB_DOES_NOT_EXIST =
-                new Client(9, "The database '%s' does not exist.");
+                new Client(10, "The database '%s' does not exist.");
         public static final Client MISSING_RESPONSE =
-                new Client(10, "Unexpected empty response for request ID '%s'.");
+                new Client(11, "Unexpected empty response for request ID '%s'.");
         public static final Client UNKNOWN_REQUEST_ID =
-                new Client(11, "Received a response with unknown request id '%s':\n%s");
+                new Client(12, "Received a response with unknown request id '%s':\n%s");
         public static final Client CLUSTER_NO_PRIMARY_REPLICA_YET =
-                new Client(12, "No replica has been marked as the primary replica for latest known term '%d'.");
+                new Client(13, "No replica has been marked as the primary replica for latest known term '%d'.");
         public static final Client CLUSTER_UNABLE_TO_CONNECT =
-                new Client(13, "Unable to connect to TypeDB Cluster. Attempted connecting to the cluster members, but none are available: '%s'.");
+                new Client(14, "Unable to connect to TypeDB Cluster. Attempted connecting to the cluster members, but none are available: '%s'.");
         public static final Client CLUSTER_REPLICA_NOT_PRIMARY =
-                new Client(14, "The replica is not the primary replica.");
+                new Client(15, "The replica is not the primary replica.");
         public static final Client CLUSTER_ALL_NODES_FAILED =
-                new Client(15, "Attempted connecting to all cluster members, but the following errors occurred: \n%s.");
+                new Client(16, "Attempted connecting to all cluster members, but the following errors occurred: \n%s.");
         public static final Client CLUSTER_USER_DOES_NOT_EXIST =
-                new Client(16, "The user '%s' does not exist.");
+                new Client(17, "The user '%s' does not exist.");
         public static final ErrorMessage CLUSTER_TOKEN_CREDENTIAL_INVALID =
-                new Client(17, "Invalid token credential.");
+                new Client(18, "Invalid token credential.");
         public static final ErrorMessage CLUSTER_PASSWORD_CREDENTIAL_EXPIRED =
-                new Client(18, "Expired password credential.");
+                new Client(19, "Expired password credential.");
 
         private static final String codePrefix = "CLI";
         private static final String messagePrefix = "Client Error";

--- a/connection/TypeDBClientImpl.java
+++ b/connection/TypeDBClientImpl.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLIENT_NOT_OPEN;
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
+import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Connection.openReq;
 import static com.vaticle.typedb.common.util.Objects.className;
 
 public abstract class TypeDBClientImpl implements TypeDBClient {
@@ -46,7 +47,7 @@ public abstract class TypeDBClientImpl implements TypeDBClient {
     private final RequestTransmitter transmitter;
     private final TypeDBDatabaseManagerImpl databaseMgr;
     private final ConcurrentMap<ByteString, TypeDBSessionImpl> sessions;
-    protected boolean connectionValidated;
+    private boolean connectionValidated;
 
     protected TypeDBClientImpl(int parallelisation) {
         NamedThreadFactory threadFactory = NamedThreadFactory.create(TYPEDB_CLIENT_RPC_THREAD_NAME);
@@ -56,7 +57,10 @@ public abstract class TypeDBClientImpl implements TypeDBClient {
         connectionValidated = false;
     }
 
-    protected abstract void validateConnection();
+    public void validateConnection() {
+        stub().connectionOpen(openReq());
+        connectionValidated = true;
+    }
 
     @Override
     public boolean isOpen() {

--- a/connection/TypeDBClientImpl.java
+++ b/connection/TypeDBClientImpl.java
@@ -56,7 +56,7 @@ public abstract class TypeDBClientImpl implements TypeDBClient {
         this.isOpen = false;
     }
 
-    protected abstract void open();
+    protected abstract void validateConnection();
 
     @Override
     public boolean isOpen() {

--- a/connection/TypeDBClientImpl.java
+++ b/connection/TypeDBClientImpl.java
@@ -58,17 +58,17 @@ public abstract class TypeDBClientImpl implements TypeDBClient {
 
     protected abstract void open();
 
+    @Override
+    public boolean isOpen() {
+        return isOpen;
+    }
+
     public static int calculateParallelisation() {
         int cores = Runtime.getRuntime().availableProcessors();
         if (cores <= 4) return 2;
         else if (cores <= 9) return 3;
         else if (cores <= 16) return 4;
         else return (int) Math.ceil(cores / 4.0);
-    }
-
-    @Override
-    public boolean isOpen() {
-        return isOpen;
     }
 
     @Override

--- a/connection/TypeDBClientImpl.java
+++ b/connection/TypeDBClientImpl.java
@@ -35,7 +35,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
-import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLIENT_NOT_OPEN;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLIENT_CLOSED;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLIENT_CONNECTION_NOT_VALIDATED;
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Connection.openReq;
 import static com.vaticle.typedb.common.util.Objects.className;
@@ -90,7 +91,7 @@ public abstract class TypeDBClientImpl implements TypeDBClient {
 
     @Override
     public TypeDBSessionImpl session(String database, TypeDBSession.Type type, TypeDBOptions options) {
-        if (!isConnectionValidated()) throw new TypeDBClientException(CLIENT_NOT_OPEN);// TODO
+        if (!isConnectionValidated()) throw new TypeDBClientException(CLIENT_CONNECTION_NOT_VALIDATED);
         TypeDBSessionImpl session = new TypeDBSessionImpl(this, database, type, options);
         assert !sessions.containsKey(session.id());
         sessions.put(session.id(), session);

--- a/connection/cluster/ClusterClient.java
+++ b/connection/cluster/ClusterClient.java
@@ -235,7 +235,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
             while (true) {
                 try {
                     FailsafeTaskParams parameter = new FailsafeTaskParams(
-                            fetchOpenServerClient(replica.address()), replica
+                            fetchValidatedServerClient(replica.address()), replica
                     );
                     return retries == 0 ? run(parameter) : rerun(parameter);
                 } catch (TypeDBClientException e) {
@@ -264,7 +264,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
             int retries = 0;
             for (ClusterDatabase.Replica replica : replicas) {
                 try {
-                    FailsafeTaskParams parameter = new FailsafeTaskParams(fetchOpenServerClient(replica.address()), replica);
+                    FailsafeTaskParams parameter = new FailsafeTaskParams(fetchValidatedServerClient(replica.address()), replica);
                     return retries == 0 ? run(parameter) : rerun(parameter);
                 } catch (TypeDBClientException e) {
                     if (UNABLE_TO_CONNECT.equals(e.getErrorMessage())) {
@@ -297,7 +297,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
             for (String serverAddress : clusterServerClients.keySet()) {
                 try {
                     LOG.debug("Fetching replica info from {}", serverAddress);
-                    ClusterDatabaseProto.ClusterDatabaseManager.Get.Res res = fetchOpenServerClient(serverAddress)
+                    ClusterDatabaseProto.ClusterDatabaseManager.Get.Res res = fetchValidatedServerClient(serverAddress)
                             .stub().databasesGet(getReq(database));
                     ClusterDatabase clusterDatabase = ClusterDatabase.of(res.getDatabase(), ClusterClient.this);
                     clusterDatabases.put(database, clusterDatabase);
@@ -322,7 +322,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
             }
         }
 
-        private ClusterServerClient fetchOpenServerClient(String address) {
+        private ClusterServerClient fetchValidatedServerClient(String address) {
             ClusterServerClient serverClient = clusterServerClient(address);
             if (!serverClient.isOpen()) serverClient.validateConnection(); // may throw exception
             return serverClient;

--- a/connection/cluster/ClusterClient.java
+++ b/connection/cluster/ClusterClient.java
@@ -93,13 +93,14 @@ public class ClusterClient implements TypeDBClient.Cluster {
         Map<String, ClusterServerClient> clients = new HashMap<>();
         boolean available = false;
         for (String address : addresses) {
+            ClusterServerClient client = new ClusterServerClient(address, credential, parallelisation);
             try {
-                ClusterServerClient client = new ClusterServerClient(address, credential, parallelisation);
-                clients.put(address, client);
+                client.open();
                 available = true;
             } catch (TypeDBClientException e) {
                 // do nothing
             }
+            clients.put(address, client);
         }
         if (!available) throw new TypeDBClientException(CLUSTER_UNABLE_TO_CONNECT, String.join(",", addresses));
         return clients;
@@ -173,7 +174,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
             Function<FailsafeTaskParams, RESULT> run,
             Function<FailsafeTaskParams, RESULT> rerun
     ) {
-        return new FailsafeTask<RESULT>(database) {
+        return new FailsafeTask<>(database) {
             @Override
             RESULT run(FailsafeTaskParams parameter) {
                 return run.apply(parameter);

--- a/connection/cluster/ClusterClient.java
+++ b/connection/cluster/ClusterClient.java
@@ -95,7 +95,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
         for (String address : addresses) {
             ClusterServerClient client = new ClusterServerClient(address, credential, parallelisation);
             try {
-                client.open();
+                client.validateConnection();
                 available = true;
             } catch (TypeDBClientException e) {
                 // do nothing
@@ -323,7 +323,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
 
         private ClusterServerClient fetchOpenServerClient(String address) {
             ClusterServerClient serverClient = clusterServerClient(address);
-            if (!serverClient.isOpen()) serverClient.open(); // may throw exception
+            if (!serverClient.isOpen()) serverClient.validateConnection(); // may throw exception
             return serverClient;
         }
 

--- a/connection/cluster/ClusterClient.java
+++ b/connection/cluster/ClusterClient.java
@@ -77,6 +77,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
     private Set<String> fetchCurrentAddresses(Set<String> servers) {
         for (String server : servers) {
             try (ClusterServerClient client = new ClusterServerClient(server, credential, parallelisation)) {
+                client.validateConnection();
                 return client.servers();
             } catch (TypeDBClientException e) {
                 if (UNABLE_TO_CONNECT.equals(e.getErrorMessage())) {

--- a/connection/cluster/ClusterClient.java
+++ b/connection/cluster/ClusterClient.java
@@ -324,7 +324,7 @@ public class ClusterClient implements TypeDBClient.Cluster {
 
         private ClusterServerClient fetchValidatedServerClient(String address) {
             ClusterServerClient serverClient = clusterServerClient(address);
-            if (!serverClient.isOpen()) serverClient.validateConnection(); // may throw exception
+            if (!serverClient.isConnectionValidated()) serverClient.validateConnection(); // may throw exception
             return serverClient;
         }
 

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -52,6 +52,7 @@ class ClusterServerClient extends TypeDBClientImpl {
         this.address = address;
         channel = createManagedChannel(address, credential);
         stub = new ClusterServerStub(channel, credential);
+        isOpen = false;
     }
 
     protected void open() {

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -55,7 +55,7 @@ class ClusterServerClient extends TypeDBClientImpl {
         isOpen = false;
     }
 
-    protected void open() {
+    protected void validateConnection() {
         try {
             stub.connectionOpen(openReq());
         } catch (Exception e) {

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -86,7 +86,7 @@ class ClusterServerClient extends TypeDBClientImpl {
     }
 
     public Set<String> servers() {
-        if (!isOpen()) throw new TypeDBClientException(CLIENT_NOT_OPEN);
+        if (!isConnectionValidated()) throw new TypeDBClientException(CLIENT_NOT_OPEN); // TODO
         LOG.debug("Fetching list of all servers from server {}...", address);
         ClusterServerProto.ServerManager.All.Res res = stub.serversAll(allReq());
         Set<String> addresses = res.getServersList().stream().map(ClusterServerProto.Server::getAddress).collect(toSet());

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -52,12 +52,16 @@ class ClusterServerClient extends TypeDBClientImpl {
         this.address = address;
         channel = createManagedChannel(address, credential);
         stub = new ClusterServerStub(channel, credential);
+    }
+
+    protected void open() {
         try {
             stub.connectionOpen(openReq());
         } catch (Exception e) {
             close();
             throw e;
         }
+        isOpen = true;
     }
 
     private ManagedChannel createManagedChannel(String address, TypeDBCredential credential) {

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -35,9 +35,8 @@ import org.slf4j.LoggerFactory;
 import javax.net.ssl.SSLException;
 import java.util.Set;
 
-import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLIENT_NOT_OPEN;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLIENT_CONNECTION_NOT_VALIDATED;
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Cluster.ServerManager.allReq;
-import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Connection.openReq;
 import static java.util.stream.Collectors.toSet;
 
 class ClusterServerClient extends TypeDBClientImpl {
@@ -86,7 +85,7 @@ class ClusterServerClient extends TypeDBClientImpl {
     }
 
     public Set<String> servers() {
-        if (!isConnectionValidated()) throw new TypeDBClientException(CLIENT_NOT_OPEN); // TODO
+        if (!isConnectionValidated()) throw new TypeDBClientException(CLIENT_CONNECTION_NOT_VALIDATED);
         LOG.debug("Fetching list of all servers from server {}...", address);
         ClusterServerProto.ServerManager.All.Res res = stub.serversAll(allReq());
         Set<String> addresses = res.getServersList().stream().map(ClusterServerProto.Server::getAddress).collect(toSet());

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -55,11 +55,6 @@ class ClusterServerClient extends TypeDBClientImpl {
         stub = new ClusterServerStub(channel, credential);
     }
 
-    protected void validateConnection() {
-        stub.connectionOpen(openReq());
-        connectionValidated = true;
-    }
-
     private ManagedChannel createManagedChannel(String address, TypeDBCredential credential) {
         if (!credential.tlsEnabled()) {
             return NettyChannelBuilder.forTarget(address)

--- a/connection/core/CoreClient.java
+++ b/connection/core/CoreClient.java
@@ -45,12 +45,6 @@ public class CoreClient extends TypeDBClientImpl {
     }
 
     @Override
-    protected void validateConnection() {
-        stub.connectionOpen(openReq());
-        connectionValidated = true;
-    }
-
-    @Override
     public ManagedChannel channel() {
         return channel;
     }

--- a/connection/core/CoreClient.java
+++ b/connection/core/CoreClient.java
@@ -41,11 +41,11 @@ public class CoreClient extends TypeDBClientImpl {
         super(parallelisation);
         channel = NettyChannelBuilder.forTarget(address).usePlaintext().build();
         stub = CoreStub.create(channel);
-        open();
+        validateConnection();
     }
 
     @Override
-    protected void open() {
+    protected void validateConnection() {
         try {
             stub.connectionOpen(openReq());
         } catch (Exception e) {

--- a/connection/core/CoreClient.java
+++ b/connection/core/CoreClient.java
@@ -41,12 +41,18 @@ public class CoreClient extends TypeDBClientImpl {
         super(parallelisation);
         channel = NettyChannelBuilder.forTarget(address).usePlaintext().build();
         stub = CoreStub.create(channel);
+        open();
+    }
+
+    @Override
+    protected void open() {
         try {
             stub.connectionOpen(openReq());
         } catch (Exception e) {
             close();
             throw e;
         }
+        isOpen = true;
     }
 
     @Override

--- a/connection/core/CoreClient.java
+++ b/connection/core/CoreClient.java
@@ -46,13 +46,8 @@ public class CoreClient extends TypeDBClientImpl {
 
     @Override
     protected void validateConnection() {
-        try {
-            stub.connectionOpen(openReq());
-        } catch (Exception e) {
-            close();
-            throw e;
-        }
-        isOpen = true;
+        stub.connectionOpen(openReq());
+        connectionValidated = true;
     }
 
     @Override

--- a/stream/RequestTransmitter.java
+++ b/stream/RequestTransmitter.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.StampedLock;
 
-import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLIENT_NOT_OPEN;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLIENT_CLOSED;
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.TRANSACTION_CLOSED;
 
 public class RequestTransmitter implements AutoCloseable {
@@ -72,7 +72,7 @@ public class RequestTransmitter implements AutoCloseable {
     public Dispatcher dispatcher(StreamObserver<TransactionProto.Transaction.Client> requestObserver) {
         try {
             accessLock.readLock().lock();
-            if (!isOpen) throw new TypeDBClientException(CLIENT_NOT_OPEN);
+            if (!isOpen) throw new TypeDBClientException(CLIENT_CLOSED);
             Executor executor = nextExecutor();
             Dispatcher dispatcher = new Dispatcher(executor, requestObserver);
             executor.dispatchers.add(dispatcher);

--- a/stream/RequestTransmitter.java
+++ b/stream/RequestTransmitter.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.StampedLock;
 
-import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLIENT_CLOSED;
+import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLIENT_NOT_OPEN;
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.TRANSACTION_CLOSED;
 
 public class RequestTransmitter implements AutoCloseable {
@@ -72,7 +72,7 @@ public class RequestTransmitter implements AutoCloseable {
     public Dispatcher dispatcher(StreamObserver<TransactionProto.Transaction.Client> requestObserver) {
         try {
             accessLock.readLock().lock();
-            if (!isOpen) throw new TypeDBClientException(CLIENT_CLOSED);
+            if (!isOpen) throw new TypeDBClientException(CLIENT_NOT_OPEN);
             Executor executor = nextExecutor();
             Dispatcher dispatcher = new Dispatcher(executor, requestObserver);
             executor.dispatchers.add(dispatcher);


### PR DESCRIPTION
## What is the goal of this PR?

To prevent null pointer errors during failover tasks being executed, we go back to the previous model of first creating a client, then opening and validating the connection.


## What are the changes implemented in this PR?

* Split client constructor and client opening internally, so that cluster-server-client can be retained and opened even if the connection is not available at the time.