### PR TITLE
Add eclipsesource-minimal-json to maven dependencies

### DIFF
--- a/dependencies/maven/artifacts.bzl
+++ b/dependencies/maven/artifacts.bzl
@@ -22,6 +22,7 @@
 artifacts = [
   "ch.qos.logback:logback-classic",
   "ch.qos.logback:logback-core",
+  "com.eclipsesource.minimal-json:minimal-json",
   "com.google.code.findbugs:annotations",
   "com.google.code.findbugs:jsr305",
   "commons-io:commons-io",


### PR DESCRIPTION
## What is the goal of this PR?
Adds `com.eclipsesource.minimal-json:minimal-json` to maven artifacts to reflect explicit dependency.

## What are the changes implemented in this PR?
* Adds `com.eclipsesource.minimal-json:minimal-json` to maven artifacts to reflect explicit dependency.
* updates.sh generates an unchanged `artifacts.snapshot` (since the dependency was transitively inherited anyway)
